### PR TITLE
Fix npm package

### DIFF
--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -14,7 +14,7 @@
     "invariant": "2.1.0",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
-    "lore": "0.6.9",
+    "lore": "0.6.10",
     "moment": "2.10.3",
     "react": "0.14.3",
     "react-dom": "0.14.2",

--- a/lore-cli/package.json
+++ b/lore-cli/package.json
@@ -14,7 +14,6 @@
   ],
   "scripts": {
     "check": "npm run lint && npm run test",
-
     "clean:node:local": "rm -rf node_modules",
     "clean:node:lore-cli-core": "rm -rf packages/lore-cli-core/node_modules",
     "clean:node:lore-generate": "rm -rf packages/lore-generate/node_modules",
@@ -28,7 +27,6 @@
     "clean:node:group2": "npm run clean:node:lore-generate-component && npm run clean:node:lore-generate-generator && npm run clean:node:lore-generate-model",
     "clean:node:group3": "npm run clean:node:lore-generate-new && npm run clean:node:lore-generate-reducer",
     "clean:node": "npm run clean:node:local && npm run clean:node:group1 && npm run clean:node:group2 && npm run clean:node:group3",
-
     "install:lore-cli-core": "cd packages/lore-cli-core && npm install",
     "install:lore-generate": "cd packages/lore-generate && npm install",
     "install:lore-generate-collection": "cd packages/lore-generate-collection && npm install",
@@ -40,13 +38,9 @@
     "install:group1": "npm run install:lore-cli-core && npm run install:lore-generate && npm run install:lore-generate-collection",
     "install:group2": "npm run install:lore-generate-component && npm run install:lore-generate-generator && npm run install:lore-generate-model",
     "install:group3": "npm run install:lore-generate-new && npm run install:lore-generate-reducer",
-
     "lint": "echo 'tbd: implement me.'",
-
     "postinstall": "npm run install:group1 && npm run install:group2 && npm run install:group3",
-
     "prepublish": "npm run check",
-
     "test:lore-cli-core": "cd packages/lore-cli-core && npm test",
     "test:lore-generate": "cd packages/lore-generate && npm test",
     "test:lore-generate-collection": "cd packages/lore-generate-collection && npm test",

--- a/lore/package.json
+++ b/lore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lore",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Storcery",
   "description": "Convention driven framework for React + Redux applications",
   "license": "MIT",

--- a/lore/packages/lore-actions/package.json
+++ b/lore/packages/lore-actions/package.json
@@ -14,7 +14,7 @@
     "build": "../../node_modules/.bin/babel src --out-dir lib",
     "clean": "rimraf lib",
     "debug": "mocha debug --compilers js:babel-core/register --recursive",
-    "prepublish": "npm run build",
+    "x-prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive"
   },
   "repository": {

--- a/lore/packages/lore-core/package.json
+++ b/lore/packages/lore-core/package.json
@@ -14,7 +14,7 @@
     "build": "../../node_modules/.bin/babel src --out-dir lib",
     "clean": "rimraf lib",
     "debug": "mocha debug test/bootstrap.js test/unit test/integration --recursive",
-    "prepublish": "npm run build",
+    "x-prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register test/bootstrap.js test/unit test/integration --recursive"
   },
   "repository": {

--- a/lore/packages/lore-models/package.json
+++ b/lore/packages/lore-models/package.json
@@ -24,7 +24,7 @@
     "build": "../../node_modules/.bin/babel src --out-dir lib",
     "clean": "rimraf lib",
     "debug": "mocha debug --compilers js:babel-core/register --recursive",
-    "prepublish": "npm run build",
+    "x-prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive"
   },
   "repository": {

--- a/lore/packages/lore-reducers/package.json
+++ b/lore/packages/lore-reducers/package.json
@@ -14,7 +14,7 @@
     "build": "../../node_modules/.bin/babel src --out-dir lib",
     "clean": "rimraf lib",
     "debug": "mocha debug --compilers js:babel-core/register --recursive",
-    "prepublish": "npm run build",
+    "x-prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes the npm package so that it no longer throws error when being installed from npm.  It also bumps lore to v0.6.10, and uses that version in the todomvc example to verify correct functionality.

**Reason for the error**

When packages are downloaded from npm they are installed under the "production" mode, which means that devDependencies are never installed.

The child packages under lore, such as lore-actions and lore-core, had a `prepublish`step defined that transpiled the code from `src` to `lib`.  This step is executed not only as a literal pre-publish step, but also when running `npm install` on the package locally.

When npm installed `lore`, it did so under the "production" setting. However, `lore` had a `postinstall` step defined that ran `npm install` on each of the child packages, such as lore-actions and lore-core.  This step was considered a "local install", and so the `prepublish` step was triggered.

The `prepublish` step for each child package attempted to transpile its code using `"../../node_modules/.bin/babel src --out-dir lib"`.  However, because `lore` was installed in "production" mode, the devDependencies (which is where babel was) were never installed.  Consequently, this build step failed, because babel didn't exist, and npm quickly removed the lore package from node_modules because it couldn't build it without an error.

**Possible Solutions**

There were two possible solutions I could identify:
1. Remove the `postinstall` build step from the child packages, and have the parent call it explicitly as part of _its_ `prepublish` step, which it does already.
2. Change the commands like `cd packages/lore-actions && npm install` to `cd packages/lore-actions && npm install --production` to prevent the build step from running.

The problem with solution 2 is that it also causes the devDependencies to never be installed, which means the tests will never pass as mocha never gets installed.  So I went with solution 1.

**Conclusion & Summary**

Solution 1 turned out to be pretty clean.  Instead of deleting the `prepublish` step in the child packages, I simply "commented it out" by renaming it to `x-prepublish`.  I left it there as a reminder, because when the packages are published on their own, this step will need to be run before hand.

It `lore-cli` ever requires transpilation, this strategy will need to be implemented for it as well.
