### PR TITLE
Add surge generator

### DIFF
--- a/lore-cli/package.json
+++ b/lore-cli/package.json
@@ -1,10 +1,10 @@
 {
   "name": "lore-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Storcery",
   "description": "Command Line Interface for Lore (A convention driven framework for React + Redux applications)",
   "license": "MIT",
-  "main": "packages/lore-cli-core/lib/index.js",
+  "main": "packages/lore-cli-core/bin/lore.js",
   "bin": {
     "lore": "packages/lore-cli-core/bin/lore.js"
   },
@@ -23,9 +23,10 @@
     "clean:node:lore-generate-model": "rm -rf packages/lore-generate-model/node_modules",
     "clean:node:lore-generate-new": "rm -rf packages/lore-generate-new/node_modules",
     "clean:node:lore-generate-reducer": "rm -rf packages/lore-generate-reducer/node_modules",
+    "clean:node:lore-generate-surge": "rm -rf packages/lore-generate-surge/node_modules",
     "clean:node:group1": "npm run clean:node:lore-cli-core && npm run clean:node:lore-generate && npm run clean:node:lore-generate-collection",
     "clean:node:group2": "npm run clean:node:lore-generate-component && npm run clean:node:lore-generate-generator && npm run clean:node:lore-generate-model",
-    "clean:node:group3": "npm run clean:node:lore-generate-new && npm run clean:node:lore-generate-reducer",
+    "clean:node:group3": "npm run clean:node:lore-generate-new && npm run clean:node:lore-generate-reducer && npm run clean:node:lore-generate-surge",
     "clean:node": "npm run clean:node:local && npm run clean:node:group1 && npm run clean:node:group2 && npm run clean:node:group3",
     "install:lore-cli-core": "cd packages/lore-cli-core && npm install",
     "install:lore-generate": "cd packages/lore-generate && npm install",
@@ -35,9 +36,10 @@
     "install:lore-generate-model": "cd packages/lore-generate-model && npm install",
     "install:lore-generate-new": "cd packages/lore-generate-new && npm install",
     "install:lore-generate-reducer": "cd packages/lore-generate-reducer && npm install",
+    "install:lore-generate-surge": "cd packages/lore-generate-surge && npm install",
     "install:group1": "npm run install:lore-cli-core && npm run install:lore-generate && npm run install:lore-generate-collection",
     "install:group2": "npm run install:lore-generate-component && npm run install:lore-generate-generator && npm run install:lore-generate-model",
-    "install:group3": "npm run install:lore-generate-new && npm run install:lore-generate-reducer",
+    "install:group3": "npm run install:lore-generate-new && npm run install:lore-generate-reducer && npm run install:lore-generate-surge",
     "lint": "echo 'tbd: implement me.'",
     "postinstall": "npm run install:group1 && npm run install:group2 && npm run install:group3",
     "prepublish": "npm run check",
@@ -49,9 +51,10 @@
     "test:lore-generate-model": "cd packages/lore-generate-model && npm test",
     "test:lore-generate-new": "cd packages/lore-generate-new && npm test",
     "test:lore-generate-reducer": "cd packages/lore-generate-reducer && npm test",
+    "test:lore-generate-surge": "cd packages/lore-generate-surge && npm test",
     "test:group1": "npm run test:lore-cli-core && npm run test:lore-generate && npm run test:lore-generate-collection",
     "test:group2": "npm run test:lore-generate-component && npm run test:lore-generate-generator && npm run test:lore-generate-model",
-    "test:group3": "npm run test:lore-generate-new && npm run test:lore-generate-reducer",
+    "test:group3": "npm run test:lore-generate-new && npm run test:lore-generate-reducer && npm run test:lore-generate-surge",
     "test": "npm run test:group1 && npm run test:group2 && npm run test:group3"
   },
   "repository": {

--- a/lore-cli/packages/lore-cli-core/bin/lore.js
+++ b/lore-cli/packages/lore-cli-core/bin/lore.js
@@ -8,18 +8,6 @@ var program = require('commander');
 var nodepath = require('path');
 var loregen = require('../../lore-generate');
 
-console.log('                                 _       ___   ____     ___    ');
-console.log('                                | |     /   \\ |    \\   /  _] ');
-console.log('                                | |    |     ||  D  ) /  [_    ');
-console.log('                                | |    |  O  ||    / |    _]   ');
-console.log('                                | |___ |     ||    \\ |   [_   ');
-console.log('                                |     ||     ||  .  \\|     |  ');
-console.log('                                |_____| \\___/ |__|\\_||_____| ');
-console.log('                                                               ');
-console.log('                               ~ BUILD APPS WORTHY OF LEGEND ~ ');
-console.log('                               -------------------------------');
-console.log('\n');
-
 var called = false;
 function call(generator) {
   return function() {
@@ -40,10 +28,10 @@ function call(generator) {
         loreRoot: nodepath.resolve(__dirname, '..'),
         args: cliArguments
       }).then(function() {
-        console.log('Generator finished successfully.')
+        console.log('Generator finished successfully.');
       }).catch(function(e) {
-        console.log('Generator failed with errors:')
-        console.log(e)
+        console.log('Generator failed with errors:');
+        console.log(e);
       });
     })(arguments);
   }
@@ -93,9 +81,13 @@ program.command('generate-reducer <reducer_name>')
   .description('generate a new Lore reducer.')
   .action(call(require('../../lore-generate-reducer')));
 
-program.command('generate-fauxserver')
-  .description('add a faux server to the Lore project.')
-  .action(call(require('../../lore-generate-fauxserver')));
+program.command('generate-surge')
+  .description('generate a gulp file for publishing your project to surge.sh')
+  .action(call(require('../../lore-generate-surge')));
+
+//program.command('generate-fauxserver')
+//  .description('add a faux server to the Lore project.')
+//  .action(call(require('../../lore-generate-fauxserver')));
 
 // $ lore
 program.parse(process.argv);

--- a/lore-cli/packages/lore-generate-new/src/index.js
+++ b/lore-cli/packages/lore-generate-new/src/index.js
@@ -18,6 +18,7 @@ module.exports = {
       './index.html': { copy: 'index.html' },
       './index.js': { copy: 'index.js' },
       './.lorerc': { jsonfile: lorerc },
+      './gulpfile.js': { copy: 'gulpfile.js' },
       './package.json': { template: 'package.json' },
       './README.md': { template: './README.md' },
       './routes.js': { copy: 'routes.js'},
@@ -84,8 +85,13 @@ module.exports = {
       './config/env/production.js': { copy: 'config/env/production.js'},
       './config/env/README.md': { copy: 'config/env/README.md'},
 
+      './gulp': { folder: {}},
+      './gulp/tasks': { folder: {}},
+      './gulp/tasks/default.js': { copy: 'gulp/tasks/default.js'},
+      './gulp/tasks/README.md': { copy: 'gulp/tasks/README.md'},
+
       './initializers': { folder: {}},
-      './initializers/REAMD.md': { copy: 'initalizers/README.md'}
+      './initializers/REAMDE.md': { copy: 'initializers/README.md'}
 
     };
   }

--- a/lore-cli/packages/lore-generate-new/templates/gulp/tasks/README.md
+++ b/lore-cli/packages/lore-generate-new/templates/gulp/tasks/README.md
@@ -1,0 +1,20 @@
+# app/gulp/tasks
+
+### Purpose
+
+This is where you should put your gulp tasks. While webpack and npm scripts have gone a long way towards
+replacing the need for gulp on many projects, it can still be useful in scenarios like publishing your
+project to Surge or GitHub Pages.
+
+### Example
+
+Let's say you want to create a gulp task that welcomes someone to your project.  To do that you would create
+a file called `hello.js` in `/gulp/tasks` and execute it by typing `gulp say:hello`.
+
+```
+// file: hello.js
+
+gulp.task('say:hello', function () {
+  console.log('Hello! Nice to meet you : )');
+});
+```

--- a/lore-cli/packages/lore-generate-new/templates/gulp/tasks/default.js
+++ b/lore-cli/packages/lore-generate-new/templates/gulp/tasks/default.js
@@ -1,0 +1,6 @@
+var gulp = require('gulp');
+
+gulp.task('default', function () {
+  console.log('Hello! Nice to meet you : )');
+  console.log("I'm the default gulp task. You can override me with something more useful.");
+});

--- a/lore-cli/packages/lore-generate-new/templates/gulpfile.js
+++ b/lore-cli/packages/lore-generate-new/templates/gulpfile.js
@@ -1,0 +1,17 @@
+/*
+  gulpfile.js
+  ===========
+  Rather than manage one giant configuration file responsible
+  for creating multiple tasks, each task has been broken out into
+  its own file in gulp/tasks. Any files in that directory get
+  automatically required below.
+
+  To add a new task, simply add a new task file in that directory.
+  gulp/tasks/default.js specifies the default set of tasks to run
+  when you run `gulp`.
+*/
+
+var requireDir = require('require-dir');
+
+// Require all tasks in gulp/tasks, including subfolders
+requireDir('./gulp/tasks', { recurse: true });

--- a/lore-cli/packages/lore-generate-new/templates/package.json
+++ b/lore-cli/packages/lore-generate-new/templates/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=test mocha --recursive"
   },
   "dependencies": {
-    "lore": "0.6.8",
+    "lore": "0.6.10",
     "classnames": "2.1.3",
     "history": "1.17.0",
     "invariant": "2.1.0",
@@ -35,6 +35,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.21.0",
     "file-loader": "0.8.4",
+    "gulp": "3.9.1",
     "json-loader": "0.5.4",
     "less": "2.5.1",
     "less-loader": "2.2.0",

--- a/lore-cli/packages/lore-generate-new/templates/webpack/config.js
+++ b/lore-cli/packages/lore-generate-new/templates/webpack/config.js
@@ -5,7 +5,7 @@
  * The intent with this file is to:
  *
  * 1. Have a build process that works out of the box so you don't have to learn Webpack until you want/need to.
- * 2. Have it include all the common loaders, so you don't have to figure out how to add things like jsx, css and images 
+ * 2. Have it include all the common loaders, so you don't have to figure out how to add things like jsx, css and images
  * into your project.
  * 3. Alias `react`, so you don't hit any issues with duplicate copies of React due to npm packages that aren't using a
  * peerDependency for React.
@@ -37,10 +37,7 @@ module.exports = function(settings) {
     resolve: {
       extensions: ['', '.js', '.jsx'],
       alias: {
-        'react/lib': APP_ROOT + '/node_modules/react/lib',
-        'react/addons': APP_ROOT + '/node_modules/react/addons',
-        'react': APP_ROOT + '/node_modules/react',
-        'globals': APP_ROOT + '/config/globals.js'
+        'react': APP_ROOT + '/node_modules/react'
       }
     },
     module: {
@@ -54,29 +51,23 @@ module.exports = function(settings) {
           query: {
             presets: ['react', 'es2015']
           }
-        },
-        {
-          test: /\.(js|jsx)$/,
-          loaders: ['react-hot', 'babel-loader'],
-          include: /node_modules\/material-ui\/src/,
-        }, {
-        test: /\.js$/,
-        loaders: ['babel-loader'],
-        include: path.join(APP_ROOT, '..', '..', 'src'),
-      }, {
-        test: /\.css/,
-        loader: 'style-loader!css-loader'
-      }, {
-        test: /\.less$/,
-        loader: 'style-loader!css-loader!less-loader'
-      }, {
-        test: /\.(png|jpg)$/,
-        loader: 'url-loader?limit=8192'
-      }, {
-        test: /\.json/,
-        loader: 'json-loader'
-      }
-      ]
+        },{
+          test: /\.js$/,
+          loaders: ['babel-loader'],
+          include: path.join(APP_ROOT, '..', '..', 'src')
+        },{
+          test: /\.css/,
+          loader: 'style-loader!css-loader'
+        },{
+          test: /\.less$/,
+          loader: 'style-loader!css-loader!less-loader'
+        },{
+          test: /\.(png|jpg)$/,
+          loader: 'url-loader?limit=8192'
+        },{
+          test: /\.json/,
+          loader: 'json-loader'
+      }]
     }
   }
 };

--- a/lore-cli/packages/lore-generate-surge/README.md
+++ b/lore-cli/packages/lore-generate-surge/README.md
@@ -1,0 +1,3 @@
+# lore-generate-surge
+
+<!-- generator description goes here -->

--- a/lore-cli/packages/lore-generate-surge/package.json
+++ b/lore-cli/packages/lore-generate-surge/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "lore-generate-surge",
+    "version": "0.1.0",
+    "private": true,
+    "author": "Storcery",
+    "license": "MIT'",
+    "description": "<!-- generator description goes here -->",
+    "keywords": ["lore", "generator"],
+    "dependencies": {
+      "bluebird": "3.1.1",
+      "lodash": "3.10.1"
+    },
+    "devDependencies": {
+      "chai": "3.4.1",
+      "mocha": "2.3.4"
+    },
+    "scripts": {
+      "test": "NODE_ENV=test mocha --recursive"
+    },
+    "main": "src/index.js",
+    "loreGenerator": {
+      "type": "lore-generate-surge",
+      "behavior": "default implementation of `lore lore-generate-surge`",
+      "loreVersion": "*"
+    }
+}

--- a/lore-cli/packages/lore-generate-surge/src/after.js
+++ b/lore-cli/packages/lore-generate-surge/src/after.js
@@ -1,0 +1,27 @@
+var Promise = require('bluebird');
+
+module.exports = function(scope) {
+  return Promise.resolve().then(function() {
+    console.log();
+    console.log('** Installation Instructions **');
+    console.log('Almost done! Just run this command to install the required packages as devDependencies:');
+    console.log('npm install gulp@3.9.1 gulp-clean@0.3.1 gulp-rename@1.2.2 gulp-sequence@0.4.5 gulp-surge@0.1.0 gulp-util@3.0.7 yargs@4.2.0 --save-dev');
+    console.log();
+    console.log('** Publishing to a custom domain **');
+    console.log('Once the packages are installed, you can run `gulp surge` to publish your project to surge.');
+    console.log('The script will pause once you see this screen:');
+    console.log();
+    console.log('    Surge - surge.sh');
+    console.log();
+    console.log('    email: name@email.com');
+    console.log('    token: *****************');
+    console.log('    project path: /users/username/lore-project/tmp');
+    console.log('    size: 2 files, 2.3 MB');
+    console.log('    domain: frozen-tunda.surge.sh');
+    console.log();
+    console.log('To proceed, simply hit enter to accept the randomly generated domain, or delete it and replace it with your own.');
+    console.log('You can also set the domain your project is published to by running `gulp surge --domain=your-custom-subdomain.surge.sh`');
+    console.log('If you want to set the default domain the task publishes to, just modify `config.domain` in `gulp/tasks/surge.sh`');
+    console.log();
+  });
+};

--- a/lore-cli/packages/lore-generate-surge/src/before.js
+++ b/lore-cli/packages/lore-generate-surge/src/before.js
@@ -1,0 +1,12 @@
+var Promise = require('bluebird');
+var path = require('path');
+var _ = require('lodash');
+var fs = require('fs');
+
+module.exports = function(scope) {
+  return Promise.resolve().then(function() {
+    var appName = scope.appName;
+    _.defaults(scope, {});
+    scope.rootPath = path.resolve(process.cwd(), appName || '');
+  });
+};

--- a/lore-cli/packages/lore-generate-surge/src/index.js
+++ b/lore-cli/packages/lore-generate-surge/src/index.js
@@ -1,0 +1,15 @@
+var path = require('path');
+
+module.exports = {
+
+  name: 'lore-generate-surge',
+	moduleDir: require('path').resolve(__dirname, '..'),
+	templatesDirectory: require('path').resolve(__dirname,'../templates'),
+	before: require('./before'),
+	after: require('./after'),
+	targets: function(scope) {
+    return {
+      './gulp/tasks/surge.js': { copy: 'gulp/tasks/surge.js'}
+    };
+  }
+};

--- a/lore-cli/packages/lore-generate-surge/templates/gulp/tasks/surge.js
+++ b/lore-cli/packages/lore-generate-surge/templates/gulp/tasks/surge.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var gulp              = require('gulp');
+var gutil             = require('gulp-util');
+var webpack           = require('webpack');
+var clean             = require('gulp-clean');
+var argv              = require('yargs').argv;
+var rename            = require('gulp-rename');
+var surge             = require('gulp-surge');
+var gulpSequence      = require('gulp-sequence');
+
+var config = {
+  dest: './tmp',
+  webpack: '../../webpack.config.js',
+  domain: '', // <= todo: change this to your-custom-domain.surge.sh
+  env: 'production'
+};
+
+/**
+ * Run webpack, making sure to load the config and set the NODE_ENV
+ */
+gulp.task('surge:webpack', ['surge:config'], function(callback) {
+  process.env.NODE_ENV = config.env;
+  var webpackConfig = require(config.webpack);
+  var myConfig = Object.create(webpackConfig);
+
+  myConfig.plugins = myConfig.plugins.concat(
+    new webpack.DefinePlugin({
+      "process.env": {
+        // This has effect on the react lib size
+        "NODE_ENV": JSON.stringify(config.env)
+      }
+    })
+    //new webpack.optimize.DedupePlugin(),
+    //new webpack.optimize.UglifyJsPlugin()
+  );
+
+  webpack(myConfig, function(err, stats) {
+    if(err) {
+      throw new gutil.PluginError('webpack:build', err);
+    }
+
+    gutil.log('[webpack:build]', stats.toString({ colors: true }));
+
+    callback();
+  });
+});
+
+/**
+ * Build the project and copy the index.html file into the resulting directory
+ */
+gulp.task('surge:build', ['surge:webpack'], function() {
+  return gulp.src(['./index.html'], {
+    base: './'
+  }).pipe(gulp.dest(config.dest));
+});
+
+/**
+ * Push project to Surge
+ */
+gulp.task('surge:publish', function(cb) {
+  return surge({
+    project: config.dest,  // Path to your static build directory
+    domain: config.domain  // Your domain or Surge subdomain
+  }).on('close', cb);
+});
+
+/**
+ * Remove any generated artifacts
+ */
+gulp.task('surge:clean',  function() {
+  return gulp.src([
+    config.dest
+  ]).pipe(clean());
+});
+
+/**
+ * Override configuration defaults if provided as command line arguments
+ */
+gulp.task('surge:config',  function() {
+  config.domain = argv.domain || config.domain;
+  config.webpack = argv.webpack || config.webpack;
+  config.env = argv.env || config.env;
+});
+
+/**
+ * Build the project and publish to the web
+ */
+gulp.task('surge', function(cb) {
+  gulpSequence(
+    'surge:clean',
+    'surge:build',
+    'surge:publish',
+    'surge:clean',
+    cb
+  );
+});

--- a/lore-cli/packages/lore-generate-surge/test/test.spec.js
+++ b/lore-cli/packages/lore-generate-surge/test/test.spec.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('an empty spec', function() {
+  it('passes', function() {
+    expect(true).to.eq(true);
+  });
+});

--- a/lore-cli/packages/lore-generate/src/helpers/file/index.js
+++ b/lore-cli/packages/lore-generate/src/helpers/file/index.js
@@ -5,8 +5,10 @@ var _ = require('lodash');
 
 module.exports = function(options) {
   return Promise.resolve().then(function() {
-    if (options.contents === void 0 ||
-        options.rootPath === void 0) {
+    if (
+      options.contents === void 0 ||
+      options.rootPath === void 0
+    ) {
       throw new Error('missing contents or rootPath options');
     }
 


### PR DESCRIPTION
This PR:
1. Adds a gulp folder and gulpfile to the `lore-generate-new` template.  This folder is intended to be a place to insert custom tasks, such as tasks that publish to Surge or GitHub Pages.
2. Adds a `lore-generate-surge` command called like `lore generate-surge` that places a surge.js file in `gulp/tasks`.  When this tasks complete, it also displays instructions on how to publish the project to surge.
3. Removed the Lore logo when using the CLI.  While charming, and I fully support it being an (optional) part of the browser dev console, I found it be distracting and to negatively impact the readability of the console when it displays before every CLI command.  But if it has a purpose or intent I'm not seeing (outside of CLI flare) let's revisit it's inclusion.  Including it in some things might be appropriate, but maybe not everything.
4. Commented out `generate-fauxserver` because for some reason it's throwing an error that `bluebird` can't be found which is preventing any of the CLI commands from executing.

**Problems that need to be addressed**

Not sure why, but when `lore-cli` is installed globally on Node 4 (haven't checked Node 5) it installs ALL of the packages into the global node_modules directory.  This is a problem, because `lore-cli-core` and `lore-cli` both claim ownership of the `lore` CLI command, but `lore-cli-core` is taking priority, and because it references the other packages using a relative path like `../.../lore-generate-collection` and that path isn't valid in the global package space, all the CLI commands are failing.

Figure out why `lore-generate-fauxserver` is failing and re-enable it as one of the lore CLI commands.
