### PR TITLE
[lore] add missing peer dependency

### DIFF
--- a/packages/lore/package.json
+++ b/packages/lore/package.json
@@ -58,6 +58,7 @@
   },
   "peerDependencies": {
     "history": "^1.17.0",
+    "json-loader": "0.5.4",
     "react": "~0.14.3",
     "react-dom": "~0.14.2",
     "react-router": "^1.0.3",


### PR DESCRIPTION
`json-loader` is a missing peerDependancy.  It's required because `src/loaders/package.js` tries to load the `package.json` file, and that fails if `json-loader` isn't installed and configured in `webpack/config.js`.

This PR adds it to the peerDependency list.
