### PR TITLE
[lore-models] use JSON for axios data type (not string)

### DIFF
--- a/packages/lore-models/src/sync.js
+++ b/packages/lore-models/src/sync.js
@@ -38,7 +38,7 @@ export default function sync( method, model, options = {} ) {
   //add a payload for PUT and POST requests
   let payload;
   if ( params.type === type.POST || params.type === type.PUT ) {
-    payload = JSON.stringify(options.attrs || model.toJSON(options));
+    payload = options.attrs || model.toJSON(options);
   }
 
   //make the naive call


### PR DESCRIPTION
This PR corrects the data type given to axios.  The `JSON.stringify({...})` function was causing data like:

```
{
   name: "Jason"
}
```

to be converted to:

`"{"name":"Jason"}"`

when sent to the server. 

This was causing the API server to see a field name of `"{"name":"Jason"}"` with a value of undefined, instead of a field name of `name` with a value of `Jason`.
