### PR TITLE
[lore-generate-component] add ES6 component templates

### DIFF
--- a/packages/lore-cli/bin/lore.js
+++ b/packages/lore-cli/bin/lore.js
@@ -13,27 +13,25 @@ function call(generator) {
   return function() {
     called = true;
 
-    // commander lowercases arguments, for some reason.  this reverts that.
-    for(i = 0; i < arguments.length; i++) { arguments[i] = argv[i + 3]; }
+    // Commander lowercases arguments, so we need to pull them
+    // from the command line directly
+    var command = argv[2];
+    var args = [argv[3]];
+    var options = argv.length > 3 ? argv.slice(4,argv.length) : [];
 
-    (function (/* arguments */) {
-      var cliArguments = Array.prototype.slice.call(arguments[0]);
-      cliArguments.pop();
-      var args = cliArguments;
-
-      return loregen({
-        generator: generator,
-        rootPath: process.cwd(),
-        modules: {},
-        loreRoot: nodepath.resolve(__dirname, '..'),
-        args: cliArguments
-      }).then(function() {
-        console.log('Generator finished successfully.');
-      }).catch(function(e) {
-        console.log('Generator failed with errors:');
-        console.log(e);
-      });
-    })(arguments);
+    return loregen({
+      generator: generator,
+      rootPath: process.cwd(),
+      modules: {},
+      loreRoot: nodepath.resolve(__dirname, '..'),
+      args: args,
+      options: options
+    }).then(function() {
+      console.log('Generator finished successfully.');
+    }).catch(function(e) {
+      console.log('Generator failed with errors:');
+      console.log(e);
+    });
   }
 }
 
@@ -73,6 +71,9 @@ program.command('generate-collection <collection_name>')
 
 program.command('generate-component <component_name>')
   .usage('<component_name>')
+  .option('--es5', 'Generate an ES5 version of the component')
+  .option('--connect', 'Wrap the component in the lore.connect decorator')
+  .option('--router', 'Configure the component to use the router')
   .description('generate a new Lore component.')
   .action(call(require('lore-generate-component')));
 

--- a/packages/lore-generate-component/src/index.js
+++ b/packages/lore-generate-component/src/index.js
@@ -9,8 +9,30 @@ module.exports = {
 	before: require('./before'),
 	after: require('./after'),
 	targets: function(scope) {
+    var isES5 = scope.options.indexOf('--es5') >= 0;
+    var hasConnect = scope.options.indexOf('--connect') >= 0;
+    var hasRouter = scope.options.indexOf('--router') >= 0;
+    var template = './component';
+
+    if (isES5) {
+      template += '.es5'
+    } else {
+      template += '.es6'
+    }
+
+    if (hasConnect) {
+      template += '.connect'
+    }
+
+    if (hasRouter) {
+      template += '.router'
+    }
+
+    template += '.js';
+
     var result = {};
-    result['./src/components/' + pascalCase(scope.componentName) + '.js'] = { copy: './componentfile.js'};
+    var componentLocation = './src/components/' + pascalCase(scope.componentName) + '.js';
+    result[componentLocation] = { template: template};
     return result;
   }
 };

--- a/packages/lore-generate-component/templates/component.es5.connect.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.js
@@ -1,27 +1,20 @@
-'use strict';
-
 var React = require('react');
-var Router = require('react-router');
 
 module.exports = lore.connect(function(getState, props) {
     return {
-      //todo: getState('todo.all', {
-        //where: { }
-      //})
+      //models: getState('model.find')
     }
   },
   React.createClass({
     displayName: '<%= componentName %>',
 
-    mixins: [Router.History],
-
     propTypes: {
-
+      //models: React.PropTypes.object.isRequired
     },
 
     render: function () {
       return (
-        <div> </div>
+        <div></div>
       );
     }
   })

--- a/packages/lore-generate-component/templates/component.es5.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.router.js
@@ -1,0 +1,24 @@
+var React = require('react');
+var Router = require('react-router');
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      //models: getState('model.find')
+    }
+  },
+  React.createClass({
+    displayName: '<%= componentName %>',
+
+    mixins: [Router.History],
+
+    propTypes: {
+      //models: React.PropTypes.object.isRequired
+    },
+
+    render: function () {
+      return (
+        <div></div>
+      );
+    }
+  })
+);

--- a/packages/lore-generate-component/templates/component.es5.js
+++ b/packages/lore-generate-component/templates/component.es5.js
@@ -1,0 +1,13 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: '<%= componentName %>',
+
+  propTypes: {},
+
+  render: function () {
+    return (
+      <div></div>
+    );
+  }
+});

--- a/packages/lore-generate-component/templates/component.es5.router.js
+++ b/packages/lore-generate-component/templates/component.es5.router.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var Router = require('react-router');
+
+module.exports = React.createClass({
+  displayName: '<%= componentName %>',
+
+  mixins: [Router.History],
+
+  propTypes: {},
+
+  render: function () {
+    return (
+      <div></div>
+    );
+  }
+});

--- a/packages/lore-generate-component/templates/component.es6.connect.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * IMPORTANT!!
+ *
+ * Lore does not yet have a lore.connect decorator compatible with ES6 classes.
+ * This template will be updated as soon as one exists.
+ */
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {};
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.es6.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.router.js
@@ -1,0 +1,27 @@
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * IMPORTANT!!
+ *
+ * Lore does not yet have a lore.connect decorator compatible with ES6 classes.
+ * This template will be updated as soon as one exists.
+ *
+ * The template for ES6 components do not currently support react-router integration.
+ * This template will be updated as soon a solution is in place.
+ */
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {};
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.es6.js
+++ b/packages/lore-generate-component/templates/component.es6.js
@@ -1,0 +1,18 @@
+import React, { Component, PropTypes } from 'react';
+
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {};
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.es6.router.js
+++ b/packages/lore-generate-component/templates/component.es6.router.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * IMPORTANT!!
+ *
+ * The template for ES6 components do not currently support react-router integration.
+ * This template will be updated as soon a solution is in place.
+ */
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {};
+
+export default <%= componentName %>;

--- a/packages/lore-generate/src/generate.js
+++ b/packages/lore-generate/src/generate.js
@@ -39,4 +39,4 @@ module.exports = generate = function(Generator, scope) {
       return Generator.after();
     });
   });
-}
+};

--- a/packages/lore-generate/src/target.js
+++ b/packages/lore-generate/src/target.js
@@ -8,39 +8,39 @@ var helpers = {
   template: require('./helpers/template'),
   jsonfile: require('./helpers/jsonfile'),
   copy: require('./helpers/copy'),
-  file: require('./helpers/file'),
+  file: require('./helpers/file')
 };
 
-module.exports = function(options) {
+module.exports = function (options) {
   var scope = options.scope;
   var target = options.target;
   var parentGenerator = options.parent;
   var log = options.log;
 
-  return Promise.each(Object.keys(target), function(targetName) {
+  return Promise.each(Object.keys(target), function (targetName) {
     scope.templatesDirectory = parentGenerator.templatesDirectory;
 
     var helper = helpers[targetName];
 
-    if(helper !== void 0) {
-      var subTarget = target[targetName]
+    if (helper !== void 0) {
+      var subTarget = target[targetName];
       if (typeof target[targetName] === 'string') {
         subTarget = {
-         templatePath: target[targetName]
+          templatePath: target[targetName]
         }
       } else if (typeof target[targetName] === 'function') {
         subTarget = {
-         data: target[targetName](scope)
+          data: target[targetName](scope)
         }
       }
 
       scope = _.merge(scope, _.isObject(subTarget) ? subTarget : {});
 
-      return helper(scope).then(function() {
+      return helper(scope).then(function () {
         console.log("|-> Generated file: " + scope.keyPath);
       });
     }
-  }).catch(function(err) {
+  }).catch(function (err) {
     console.error(err);
   });
-}
+};


### PR DESCRIPTION
This PR addresses #57.  Now when you run `lore generate-component MyComponent` it will default to an ES6 component, like so:

``` js
import React, { Component, PropTypes } from 'react';

class Hello extends Component {
  constructor(props) {
    super(props);
  }

  render() {
    return (
      <div></div>
    )
  }
}

Hello.propTypes = {};

export default Hello;
```

And if you call `lore generate-component MyComponent --es5` it will generate the ES5 version:

``` js
var React = require('react');

module.exports = React.createClass({
  displayName: 'Hello',

  propTypes: {},

  render: function () {
    return (
      <div></div>
    );
  }
});
```

Additionally, there are now options for `--connect` and `--router`, which will also wrap the component in lore.connect or configure it to use react-router.  You can also mix and match arguments; all combinations are supported (`--es5`, `--es5 --router`, `--connect --router`, etc.)

**Note that the ES6 template is now the default**.  _HOWEVER_, there is no lore.connect decorator that supports that style yet, and I need to refresh my memory about how to use react-router with ES6 components, so for the moment, all ES6 templates produce the same component.  But I did opt to at least place a comment at the top explaining what's missing in the template and that the template will be updated as soon as a solution is in place.
