### PR TITLE
[lore] remove webpack warning

### DIFF
--- a/packages/lore/src/loaders/coreHooks.js
+++ b/packages/lore/src/loaders/coreHooks.js
@@ -4,12 +4,21 @@ var DEFAULT_HOOKS = require('../defaultHooks');
 module.exports = {
 
   load: function() {
-    // This line makes sure webpack loads all the core hooks so that
-    // the ones we need are available when we ask for them below
-    // TODO: do this in a way that doesn't cause webpack to display a warning
-    if (require.context) {
-      require.context('../hooks', true, /\.js$/);
-    }
+    // In theory, this line is required in order for Webpack to load all the hooks
+    // into bundle.js, as the require(...) statement below is a dynamically composed
+    // string, which could make it impossible for Webpack to know which files it needs
+    // to include at build time. But currently, this line doesn't appear to be required.
+    //
+    // I *think* it's because DEFAULT_HOOKS below is a static file, and webpack is able
+    // to do some static analysis to compose the require(...) statements and know which
+    // files it needs to include.
+    //
+    // I'm commenting this line out, so Webpack stops displaying a warning in the browser,
+    // but I'm leaving it in the code because it may only be coincidental that we can remove
+    // it right now (i.e. if DEFAULT_HOOKS is removed, we may need it again and I want this
+    // comment near that code to help with errors if/when they happen).
+    //
+    // require.context('../hooks', true, /\.js$/);
 
     return _.reduce(DEFAULT_HOOKS, function (hooks, hookEnabled, hookIdentity) {
       // If true, load the hook from `src/hooks/:hookIdentity`

--- a/packages/lore/test/integration/redux.spec.js
+++ b/packages/lore/test/integration/redux.spec.js
@@ -296,7 +296,7 @@ describe('lore#redux', function() {
     });
   });
 
-  describe.only('action-reducer flow: actions.todo.fetchAll() [id as Number]', function() {
+  describe('action-reducer flow: actions.todo.fetchAll() [id as Number]', function() {
 
     beforeEach(function() {
       nock('https://api.example.com')


### PR DESCRIPTION
This PR solves #55, but this solution concerns me, because I didn't think it should have worked.  See comment in the commits below about static analysis and require.context.

The original solution I tried was to modify `require.context` or `require.prototype.context` and make it a no-op function (`function(){}`), but it appears that every file (module) in Node uses a different instance of require, and I couldn't figure out how to modify require across all files.

I wanted to add a duck typed method to require.context in the bootstrap.js file in the test setup, for that didn't work, as it was only file for that specific file, and didn't transfer to the rest of the codebase.
