### PR TITLE
[lore] remove required where clause for 'model.all'

### DIFF
--- a/packages/lore/src/hooks/connect/getState.js
+++ b/packages/lore/src/hooks/connect/getState.js
@@ -23,6 +23,14 @@ module.exports = function(lore) {
         }
       }
 
+      // NOTE: this line (and the defaultParams creation in value) was created
+      // in order to prevent the need to pass `{where: {}}` into the `model.all`
+      // call. But there's undoubtedly a better way to do it. This approach should
+      // be refactored/re-examined when pagination is implemented.
+      if (value.defaultParams) {
+        params = _.defaultsDeep(params || {}, value.defaultParams);
+      }
+
       if (value.params) {
         param = params[value.params];
         if (!param) {
@@ -73,7 +81,10 @@ module.exports = function(lore) {
     if (reducerState === 'all') {
       stateMap = {
         action: modelName + '.fetchAll',
-        params: 'where'
+        params: 'where',
+        defaultParams: {
+          where: {}
+        }
       };
     } else if (reducerState === 'byId') {
       stateMap = {


### PR DESCRIPTION
This PR addresses #51.  It removes the need to pass a `where: {}` clause into `getState('model.all')`.  So now instead of writing this:

``` js
lore.connect(function(getState, props) {
   return {
      models: getState('model.all', {
         where: {}
      })
   }
})
```

You can simply write:

``` js
lore.connect(function(getState, props) {
   return {
      models: getState('model.all')
   }
})
```

And you only need to include the `where: {}` clause when you actually need to filter the data.
