### PR TITLE
[lore-cli] switch cmd separator to colon instead of hyphen

### DIFF
--- a/packages/lore-cli/bin/lore.js
+++ b/packages/lore-cli/bin/lore.js
@@ -54,22 +54,22 @@ program.command('new <app_name>')
   .description('generate a new Lore project.')
   .action(call(require('lore-generate-new')));
 
-program.command('generate-generator <generator_name> [generator_description]')
+program.command('generate:generator <generator_name> [generator_description]')
   .usage('<generator_name> [generator_description]')
   .description('generate a new Lore generator.')
   .action(call(require('lore-generate-generator')));
 
-program.command('generate-model <model_name>')
+program.command('generate:model <model_name>')
   .usage('<model_name>')
   .description('generate a new Lore model.')
   .action(call(require('lore-generate-model')));
 
-program.command('generate-collection <collection_name>')
+program.command('generate:collection <collection_name>')
   .usage('<collection_name>')
   .description('generate a new Lore collection.')
   .action(call(require('lore-generate-collection')));
 
-program.command('generate-component <component_name>')
+program.command('generate:component <component_name>')
   .usage('<component_name>')
   .option('--es5', 'Generate an ES5 version of the component')
   .option('--connect', 'Wrap the component in the lore.connect decorator')
@@ -77,12 +77,12 @@ program.command('generate-component <component_name>')
   .description('generate a new Lore component.')
   .action(call(require('lore-generate-component')));
 
-program.command('generate-reducer <reducer_name>')
+program.command('generate:reducer <reducer_name>')
   .usage('<reducer_name>')
   .description('generate a new Lore reducer.')
   .action(call(require('lore-generate-reducer')));
 
-program.command('generate-surge')
+program.command('generate:surge')
   .description('generate a gulp file for publishing your project to surge.sh')
   .action(call(require('lore-generate-surge')));
 

--- a/packages/lore-generate-component/src/before.js
+++ b/packages/lore-generate-component/src/before.js
@@ -2,13 +2,14 @@ var Promise = require('bluebird');
 var path = require('path');
 var _ = require('lodash');
 var fs = require('fs');
+var pascalCase = require('pascal-case');
 
 module.exports = function(scope) {
   return Promise.resolve().then(function() {
     _.defaults(scope, { });
 
     scope.rootPath = path.resolve(process.cwd());
-    scope.componentName = scope.args[0];
+    scope.componentName = pascalCase(scope.args[0]);
 
     if(scope.componentName === void 0) {
       throw new Error('Missing component name.');

--- a/packages/lore-generate-component/src/index.js
+++ b/packages/lore-generate-component/src/index.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var pascalCase = require('pascal-case');
 
 module.exports = {
 
@@ -31,7 +30,7 @@ module.exports = {
     template += '.js';
 
     var result = {};
-    var componentLocation = './src/components/' + pascalCase(scope.componentName) + '.js';
+    var componentLocation = './src/components/' + scope.componentName + '.js';
     result[componentLocation] = { template: template};
     return result;
   }


### PR DESCRIPTION
This PR addresses #45. 

**Changes**
1. Commands like `lore generate-model` and now `lore generate:model`.
2. Fixed a bug where the name of the ES6 component could be camelCase instead of PascalCase (`myComponent extends Component` instead of `MyComponent extends Component`)
3. ~~Added short flags to `lore generate:component --es5 --connect --router` so someone can type `lore generate:component MyComponent -e -c -r` if they want.~~

3 is crossed out per #69.
