### PR TITLE
[lore-generate-component] add lore.connect to ES6 component template

### DIFF
--- a/packages/lore-generate-component/templates/component.es5.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.router.js
@@ -9,6 +9,14 @@ module.exports = lore.connect(function(getState, props) {
   React.createClass({
     displayName: '<%= componentName %>',
 
+    /**
+     * This mixin provides a 'history' object on 'this'.
+     * To navigate to a new route, call it like this:
+     * this.history.pushState(null, '/the/new/url');
+     *
+     * Learn more about routing and the history object at:
+     * https://github.com/reactjs/react-router/blob/v1.0.3/docs/API.md#history-mixin
+     */
     mixins: [Router.History],
 
     propTypes: {

--- a/packages/lore-generate-component/templates/component.es5.router.js
+++ b/packages/lore-generate-component/templates/component.es5.router.js
@@ -4,6 +4,14 @@ var Router = require('react-router');
 module.exports = React.createClass({
   displayName: '<%= componentName %>',
 
+  /**
+   * This mixin provides a 'history' object on 'this'.
+   * To navigate to a new route, call it like this:
+   * this.history.pushState(null, '/the/new/url');
+   *
+   * Learn more at:
+   * https://github.com/reactjs/react-router/blob/v1.0.3/docs/API.md#history-mixin
+   */
   mixins: [Router.History],
 
   propTypes: {},

--- a/packages/lore-generate-component/templates/component.es6.connect.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.js
@@ -1,15 +1,15 @@
 import React, { Component, PropTypes } from 'react';
 
-/**
- * IMPORTANT!!
- *
- * Lore does not yet have a lore.connect decorator compatible with ES6 classes.
- * This template will be updated as soon as one exists.
- */
 class <%= componentName %> extends Component {
 
   constructor(props) {
     super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
   }
 
   render() {
@@ -19,6 +19,14 @@ class <%= componentName %> extends Component {
   }
 }
 
-<%= componentName %>.propTypes = {};
+<%= componentName %>.propTypes = {
+  //models: React.PropTypes.object.isRequired
+};
 
-export default <%= componentName %>;
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = lore.connect((getState, props) => {
+  return {
+    //models: getState('model.find')
+  };
+}, <%= componentName %>);

--- a/packages/lore-generate-component/templates/component.es6.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.router.js
@@ -3,16 +3,19 @@ import React, { Component, PropTypes } from 'react';
 /**
  * IMPORTANT!!
  *
- * Lore does not yet have a lore.connect decorator compatible with ES6 classes.
- * This template will be updated as soon as one exists.
- *
- * The template for ES6 components do not currently support react-router integration.
+ * The template for ES6 components does not currently support react-router integration.
  * This template will be updated as soon a solution is in place.
  */
 class <%= componentName %> extends Component {
 
   constructor(props) {
     super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
   }
 
   render() {
@@ -24,4 +27,6 @@ class <%= componentName %> extends Component {
 
 <%= componentName %>.propTypes = {};
 
-export default <%= componentName %>;
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.es6.js
+++ b/packages/lore-generate-component/templates/component.es6.js
@@ -4,6 +4,12 @@ class <%= componentName %> extends Component {
 
   constructor(props) {
     super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
   }
 
   render() {
@@ -15,4 +21,6 @@ class <%= componentName %> extends Component {
 
 <%= componentName %>.propTypes = {};
 
-export default <%= componentName %>;
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.es6.router.js
+++ b/packages/lore-generate-component/templates/component.es6.router.js
@@ -3,13 +3,19 @@ import React, { Component, PropTypes } from 'react';
 /**
  * IMPORTANT!!
  *
- * The template for ES6 components do not currently support react-router integration.
+ * The template for ES6 components does not currently support react-router integration.
  * This template will be updated as soon a solution is in place.
  */
 class <%= componentName %> extends Component {
 
   constructor(props) {
     super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
   }
 
   render() {
@@ -21,4 +27,6 @@ class <%= componentName %> extends Component {
 
 <%= componentName %>.propTypes = {};
 
-export default <%= componentName %>;
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = <%= componentName %>;


### PR DESCRIPTION
This PR addresses #64.  Changed "export default" to "module.exports = ".  See #71 for a discussion about why (looking for a solution).

Not sure how to integrate react-router into ES6 components yet.
