### PR TITLE
Create generator for tutorial

### DIFF
--- a/packages/lore-cli/bin/lore.js
+++ b/packages/lore-cli/bin/lore.js
@@ -86,6 +86,11 @@ program.command('generate:surge')
   .description('generate a gulp file for publishing your project to surge.sh')
   .action(call(require('lore-generate-surge')));
 
+program.command('generate:tutorial <step>')
+  .usage('<step>')
+  .description('generate files for the specified tutorial step.')
+  .action(call(require('lore-generate-tutorial')));
+
 //program.command('generate-fauxserver')
 //  .description('add a faux server to the Lore project.')
 //  .action(call(require('../../lore-generate-fauxserver')));

--- a/packages/lore-cli/package.json
+++ b/packages/lore-cli/package.json
@@ -29,7 +29,8 @@
     "lore-generate-collection": "^0.6.12",
     "lore-generate-component": "^0.6.16",
     "lore-generate-reducer": "^0.6.12",
-    "lore-generate-surge": "^0.6.12"
+    "lore-generate-surge": "^0.6.12",
+    "lore-generate-tutorial": "^0.6.12"
   },
   "devDependencies": {
     "bluebird": "3.1.1",

--- a/packages/lore-generate-tutorial/README.md
+++ b/packages/lore-generate-tutorial/README.md
@@ -1,0 +1,3 @@
+# lore-generate-tutorial
+
+<!-- generator description goes here -->

--- a/packages/lore-generate-tutorial/package.json
+++ b/packages/lore-generate-tutorial/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "lore-generate-tutorial",
+  "version": "0.6.12",
+  "license": "MIT",
+  "main": "src/index.js",
+  "description": "Generates code for the Lore tutorial",
+  "keywords": [
+    "lore",
+    "generator"
+  ],
+  "scripts": {
+    "test": "NODE_ENV=test mocha --recursive"
+  },
+  "dependencies": {
+    "bluebird": "3.1.1",
+    "lodash": "3.10.1"
+  },
+  "devDependencies": {
+    "chai": "3.4.1",
+    "mocha": "2.3.4"
+  }
+}

--- a/packages/lore-generate-tutorial/src/after.js
+++ b/packages/lore-generate-tutorial/src/after.js
@@ -1,0 +1,7 @@
+var Promise = require('bluebird');
+
+module.exports = function(scope) {
+  return Promise.resolve().then(function() {
+
+  });
+};

--- a/packages/lore-generate-tutorial/src/before.js
+++ b/packages/lore-generate-tutorial/src/before.js
@@ -1,0 +1,14 @@
+var Promise = require('bluebird');
+var path = require('path');
+var _ = require('lodash');
+var fs = require('fs');
+
+module.exports = function(scope) {
+  return Promise.resolve().then(function() {
+    var appName = scope.appName;
+    _.defaults(scope, {});
+    scope.step = scope.args[0];
+    scope.rootPath = path.resolve(process.cwd(), appName || '');
+    scope.overwriteFiles = true;
+  });
+};

--- a/packages/lore-generate-tutorial/src/index.js
+++ b/packages/lore-generate-tutorial/src/index.js
@@ -1,0 +1,110 @@
+var path = require('path');
+
+/**
+ * Helper function to generate a file mapping between a given step
+ * number and it's folder location in ../templates
+ *
+ * Example call:
+ * filesForStep('step1')([
+ *   'src/components/Header.js'
+ * ])
+ *
+ * Returns:
+ * {
+ *   './src/components/Header.js': 'step1/src/components/Header.js'
+ * }
+ *
+ * @param {String} step Name of the tutorial step, also name of folder
+ * @returns {Function} Curry function taking an array of file names
+ */
+function filesForStep(step) {
+  return function(files) {
+    var result = {};
+    files.forEach(function(file) {
+      var output = './' + file;
+      var target = step + '/' + file;
+      result[output] = {
+        copy: target
+      };
+    });
+    return result;
+  }
+}
+
+module.exports = {
+
+  name: 'lore-generate-tutorial',
+	moduleDir: require('path').resolve(__dirname, '..'),
+	templatesDirectory: require('path').resolve(__dirname,'../templates'),
+	before: require('./before'),
+	after: require('./after'),
+	targets: function(scope) {
+    var files = filesForStep(scope.step);
+
+    switch(scope.step) {
+      case 'step1':
+        return files([
+          'index.html'
+        ]);
+      case 'step2':
+        return files([
+          'src/components/Header.js',
+          'src/components/Layout.js'
+        ]);
+      case 'step3':
+        return files([
+          'src/components/ColorCreator.js',
+          'src/components/Layout.js'
+        ]);
+      case 'step4':
+        return files([
+          'src/components/ColorCreator.js'
+        ]);
+      case 'step5':
+        return files([
+          'src/models/color.js'
+        ]);
+      case 'step6':
+        return files([
+          'src/components/ColorCreator.js'
+        ]);
+      case 'step7':
+        return files([
+          'src/components/ColorCreator.js'
+        ]);
+      case 'step8':
+        return files([
+          'src/components/ColorCreator.js'
+        ]);
+      case 'step9':
+        return files([
+          'src/components/Color.js',
+          'src/components/ColorCreator.js'
+        ]);
+      case 'step10':
+        return files([
+          'src/components/Color.js'
+        ]);
+      case 'step11':
+        return files([
+          'routes.js',
+          'src/components/Guessatron.js',
+          'src/components/Layout.js'
+        ]);
+      case 'step12':
+        return files([
+          'src/components/Guessatron.js'
+        ]);
+      case 'step13':
+        return files([
+          'src/components/Guessatron.js'
+        ]);
+      case 'step14':
+        return files([
+          'src/components/Guessatron.js'
+        ]);
+      default:
+        return {};
+    }
+  }
+};

--- a/packages/lore-generate-tutorial/templates/step1/index.html
+++ b/packages/lore-generate-tutorial/templates/step1/index.html
@@ -1,0 +1,26 @@
+<!--This is the HTML file that gets served to the browser.  It contains text-->
+<!--that says "Loading..." that will disappear as soon as `bundle.js` has been-->
+<!--downloaded and `lore.summon()` has finished setting up your application.-->
+
+<!--It also contains a DOM element to hang dialogs from so they don't conflict-->
+<!--with any CSS or JavaScript behaviors in the application (styling overrides-->
+<!--or event bubbling cancellation).-->
+
+<html>
+  <head>
+    <title>Guessatron 5000</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div id="root">
+      <h1 class="loading-text">
+        Loading...
+      </h1>
+    </div>
+    <div id="dialog"></div>
+
+    <script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/packages/lore-generate-tutorial/templates/step10/src/components/Color.js
+++ b/packages/lore-generate-tutorial/templates/step10/src/components/Color.js
@@ -1,0 +1,23 @@
+var React = require('react');
+var Router = require('react-router');
+
+module.exports = React.createClass({
+  displayName: 'Color',
+
+  propTypes: {
+    color: React.PropTypes.object.isRequired
+  },
+
+  render: function () {
+    var color = this.props.color;
+
+    return (
+      <Router.Link
+        to={'/colors/' + color.id}
+        className="list-group-item"
+        activeClassName="active">
+        {color.data.name}
+      </Router.Link>
+    );
+  }
+});

--- a/packages/lore-generate-tutorial/templates/step11/routes.js
+++ b/packages/lore-generate-tutorial/templates/step11/routes.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Route, IndexRoute, Redirect } from 'react-router';
+
+/**
+ * Routes are used to declare your view hierarchy
+ * See: https://github.com/rackt/react-router/blob/master/docs/API.md
+ */
+var Master = require('./src/components/Master');
+var Layout = require('./src/components/Layout');
+var Guessatron = require('./src/components/Guessatron');
+
+module.exports = (
+  <Route component={Master}>
+    <Route path="/" component={Layout}>
+      <Route path="colors/:colorId" component={Guessatron} />
+    </Route>
+  </Route>
+);

--- a/packages/lore-generate-tutorial/templates/step11/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/step11/src/components/Guessatron.js
@@ -1,0 +1,44 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: 'Guessatron',
+
+  propTypes: {
+    color: React.PropTypes.object.isRequired
+  },
+
+  getDefaultProps: function() {
+    return {
+      color: {
+        data: {
+          name: 'DeepSkyBlue'
+        }
+      }
+    }
+  },
+
+  render: function() {
+    var color = this.props.color;
+
+    return (
+      <div>
+        <h2>Guessatron Result</h2>
+        <div className="media">
+          <div className="media-left">
+            <a href="#">
+              <div
+                className="media-object"
+                style={{height: '64px', width: '64px', backgroundColor: '#00BFFF'}} />
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">{color.data.name}</h4>
+            <em>Is this your color?</em>
+            <div>I hope it is because it's the only color I know.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step11/src/components/Layout.js
+++ b/packages/lore-generate-tutorial/templates/step11/src/components/Layout.js
@@ -1,0 +1,26 @@
+var React = require('react');
+var Header = require('./Header');
+var ColorCreator = require('./ColorCreator');
+
+module.exports = React.createClass({
+  displayName: 'Layout',
+
+  render: function() {
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-4">
+              <ColorCreator/>
+            </div>
+            <div className="col-md-offset-1 col-md-7">
+              {React.cloneElement(this.props.children || <span/>)}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step12/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/step12/src/components/Guessatron.js
@@ -1,0 +1,42 @@
+var React = require('react');
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      color: getState('color.byId', {
+        id: props.params.colorId
+      })
+    }
+  },
+  React.createClass({
+    displayName: 'Guessatron',
+
+    propTypes: {
+      color: React.PropTypes.object.isRequired
+    },
+
+    render: function() {
+      var color = this.props.color;
+
+      return (
+        <div>
+          <h2>Guessatron Result</h2>
+          <div className="media">
+            <div className="media-left">
+              <a href="#">
+                <div
+                  className="media-object"
+                  style={{height: '64px', width: '64px', backgroundColor: '#00BFFF'}} />
+              </a>
+            </div>
+            <div className="media-body">
+              <h4 className="media-heading">{color.data.name}</h4>
+              <em>Is this your color?</em>
+              <div>I hope it is because it's the only color I know.</div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step13/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/step13/src/components/Guessatron.js
@@ -1,0 +1,44 @@
+var React = require('react');
+var randomColor = require('randomcolor');
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      color: getState('color.byId', {
+        id: props.params.colorId
+      })
+    }
+  },
+  React.createClass({
+    displayName: 'Guessatron',
+
+    propTypes: {
+      color: React.PropTypes.object.isRequired
+    },
+
+    render: function() {
+      var color = this.props.color;
+      var generatedColor = randomColor();
+
+      return (
+        <div>
+          <h2>Guessatron Result</h2>
+          <div className="media">
+            <div className="media-left">
+              <a href="#">
+                <div
+                  className="media-object"
+                  style={{height: '64px', width: '64px', backgroundColor: generatedColor}} />
+              </a>
+            </div>
+            <div className="media-body">
+              <h4 className="media-heading">{color.data.name}</h4>
+              <em>Is this your color?</em>
+              <div>I hope it is because it's the only color I know.</div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step14/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/step14/src/components/Guessatron.js
@@ -1,0 +1,65 @@
+var React = require('react');
+var randomColor = require('randomcolor');
+
+/**
+ * Returns a random integer between min and max
+ */
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/**
+ * Return a random bragging phase so the Guessatron can let
+ * you know how awesome it is.
+ */
+function getBragPhrase() {
+  var bragPhrases = [
+    "I'm pretty sure I nailed it.",
+    "Impressive right? Don't be shy. I know I'm awesome.",
+    "YOU'RE WELCOME."
+  ];
+  return bragPhrases[getRandomInt(0,bragPhrases.length - 1)];
+}
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      color: getState('color.byId', {
+        id: props.params.colorId
+      })
+    }
+  },
+  React.createClass({
+    displayName: 'Guessatron',
+
+    propTypes: {
+      color: React.PropTypes.object.isRequired
+    },
+
+    render: function() {
+      var color = this.props.color;
+      var generatedColor = randomColor();
+      var bragPhrase = getBragPhrase();
+
+      return (
+        <div>
+          <h2>Guessatron Result</h2>
+          <div className="media">
+            <div className="media-left">
+              <a href="#">
+                <div
+                  className="media-object"
+                  style={{height: '64px', width: '64px', backgroundColor: generatedColor}} />
+              </a>
+            </div>
+            <div className="media-body">
+              <h4 className="media-heading">{color.data.name}</h4>
+              <em>Is this your color?</em>
+              <div>{bragPhrase}</div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step2/src/components/Header.js
+++ b/packages/lore-generate-tutorial/templates/step2/src/components/Header.js
@@ -1,0 +1,19 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: 'Header',
+
+  render: function () {
+    return (
+      <nav className="navbar navbar-default">
+        <div className="container">
+          <div className="navbar-header">
+            <a className="navbar-brand" href="#">
+              Guessatron 5000
+            </a>
+          </div>
+        </div>
+      </nav>
+    );
+  }
+});

--- a/packages/lore-generate-tutorial/templates/step2/src/components/Layout.js
+++ b/packages/lore-generate-tutorial/templates/step2/src/components/Layout.js
@@ -1,0 +1,25 @@
+var React = require('react');
+var Header = require('./Header');
+
+module.exports = React.createClass({
+  displayName: 'Layout',
+
+  render: function() {
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-4">
+              {/* Color creator will go here */}
+            </div>
+            <div className="col-md-offset-1 col-md-7">
+              {/* Guessatron's result will go here */}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step3/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step3/src/components/ColorCreator.js
@@ -1,0 +1,54 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: 'ColorCreator',
+
+  propTypes: {
+    colors: React.PropTypes.object.isRequired
+  },
+
+  getDefaultProps: function() {
+    return {
+      colors: {
+        data: [
+          {id: 1, cid: 'c1', data: {name: 'Red'}},
+          {id: 2, cid: 'c2', data: {name: 'Green'}},
+          {id: 3, cid: 'c3', data: {name: 'Blue'}}
+        ]
+      }
+    };
+  },
+
+  renderColor: function(color) {
+    return (
+      <a key={color.id || color.cid} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  },
+
+  render: function() {
+    var colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?" />
+              <span className="input-group-btn">
+                <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                  Create
+                </button>
+              </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step3/src/components/Layout.js
+++ b/packages/lore-generate-tutorial/templates/step3/src/components/Layout.js
@@ -1,0 +1,26 @@
+var React = require('react');
+var Header = require('./Header');
+var ColorCreator = require('./ColorCreator');
+
+module.exports = React.createClass({
+  displayName: 'Layout',
+
+  render: function() {
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-4">
+              <ColorCreator/>
+            </div>
+            <div className="col-md-offset-1 col-md-7">
+              {/* Guessatron's result will go here */}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step4/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step4/src/components/ColorCreator.js
@@ -1,0 +1,90 @@
+var React = require('react');
+
+var ENTER_KEY = 13;
+
+module.exports = React.createClass({
+  displayName: 'ColorCreator',
+
+  propTypes: {
+    colors: React.PropTypes.object.isRequired
+  },
+
+  getDefaultProps: function() {
+    return {
+      colors: {
+        data: [
+          {id: 1, data: {name: 'Red'}},
+          {id: 2, data: {name: 'Green'}},
+          {id: 3, data: {name: 'Blue'}}
+        ]
+      }
+    };
+  },
+
+  getInitialState: function () {
+    return {
+      newColor: ''
+    };
+  },
+
+  onChangeNewColor: function (event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  },
+
+  onKeyDownNewColor: function (event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  },
+
+  onCreateColor: function() {
+    var value = this.state.newColor.trim();
+
+    if (value) {
+      console.log('Creating color: ' + value);
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  },
+
+  renderColor: function(color) {
+    return (
+      <a key={color.id} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  },
+
+  render: function() {
+    var colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyDownNewColor}
+            onChange={this.onChangeNewColor} />
+              <span className="input-group-btn">
+                <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                  Create
+                </button>
+              </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/packages/lore-generate-tutorial/templates/step5/src/models/color.js
+++ b/packages/lore-generate-tutorial/templates/step5/src/models/color.js
@@ -1,0 +1,3 @@
+module.exports = {
+
+};

--- a/packages/lore-generate-tutorial/templates/step6/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step6/src/components/ColorCreator.js
@@ -1,0 +1,83 @@
+var React = require('react');
+
+var ENTER_KEY = 13;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      colors: getState('color.find')
+    }
+  },
+  React.createClass({
+    displayName: 'ColorCreator',
+
+    propTypes: {
+      colors: React.PropTypes.object.isRequired
+    },
+
+    getInitialState: function () {
+      return {
+        newColor: ''
+      };
+    },
+
+    onChangeNewColor: function (event) {
+      this.setState({
+        newColor: event.target.value
+      });
+    },
+
+    onKeyDownNewColor: function (event) {
+      if (event.charCode !== ENTER_KEY) {
+        return;
+      }
+      this.onCreateColor();
+    },
+
+    onCreateColor: function() {
+      var value = this.state.newColor.trim();
+
+      if (value) {
+        console.log('Creating color: ' + value);
+
+        this.setState({
+          newColor: ''
+        });
+      }
+    },
+
+    renderColor: function(color) {
+      return (
+        <a key={color.id} className="list-group-item">
+          {color.data.name}
+        </a>
+      );
+    },
+
+    render: function() {
+      var colors = this.props.colors;
+
+      return (
+        <div>
+          <h2>Color Requests</h2>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="What color should Guessatron display?"
+              value={this.state.newColor}
+              onKeyPress={this.onKeyDownNewColor}
+              onChange={this.onChangeNewColor} />
+                <span className="input-group-btn">
+                  <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                    Create
+                  </button>
+                </span>
+          </div>
+          <div className="list-group" style={{paddingTop: '16px'}}>
+            {colors.data.map(this.renderColor)}
+          </div>
+        </div>
+      );
+    }
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step7/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step7/src/components/ColorCreator.js
@@ -1,0 +1,85 @@
+var React = require('react');
+
+var ENTER_KEY = 13;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      colors: getState('color.find')
+    }
+  },
+  React.createClass({
+    displayName: 'ColorCreator',
+
+    propTypes: {
+      colors: React.PropTypes.object.isRequired
+    },
+
+    getInitialState: function () {
+      return {
+        newColor: ''
+      };
+    },
+
+    onChangeNewColor: function (event) {
+      this.setState({
+        newColor: event.target.value
+      });
+    },
+
+    onKeyDownNewColor: function (event) {
+      if (event.charCode !== ENTER_KEY) {
+        return;
+      }
+      this.onCreateColor();
+    },
+
+    onCreateColor: function() {
+      var value = this.state.newColor.trim();
+
+      if (value) {
+        lore.actions.color.create({
+          name: value
+        });
+
+        this.setState({
+          newColor: ''
+        });
+      }
+    },
+
+    renderColor: function(color) {
+      return (
+        <a key={color.id} className="list-group-item">
+          {color.data.name}
+        </a>
+      );
+    },
+
+    render: function() {
+      var colors = this.props.colors;
+
+      return (
+        <div>
+          <h2>Color Requests</h2>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="What color should Guessatron display?"
+              value={this.state.newColor}
+              onKeyPress={this.onKeyDownNewColor}
+              onChange={this.onChangeNewColor} />
+                <span className="input-group-btn">
+                  <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                    Create
+                  </button>
+                </span>
+          </div>
+          <div className="list-group" style={{paddingTop: '16px'}}>
+            {colors.data.map(this.renderColor)}
+          </div>
+        </div>
+      );
+    }
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step8/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step8/src/components/ColorCreator.js
@@ -1,0 +1,85 @@
+var React = require('react');
+
+var ENTER_KEY = 13;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      colors: getState('color.find')
+    }
+  },
+  React.createClass({
+    displayName: 'ColorCreator',
+
+    propTypes: {
+      colors: React.PropTypes.object.isRequired
+    },
+
+    getInitialState: function () {
+      return {
+        newColor: ''
+      };
+    },
+
+    onChangeNewColor: function (event) {
+      this.setState({
+        newColor: event.target.value
+      });
+    },
+
+    onKeyDownNewColor: function (event) {
+      if (event.charCode !== ENTER_KEY) {
+        return;
+      }
+      this.onCreateColor();
+    },
+
+    onCreateColor: function() {
+      var value = this.state.newColor.trim();
+
+      if (value) {
+        lore.actions.color.create({
+          name: value
+        });
+
+        this.setState({
+          newColor: ''
+        });
+      }
+    },
+
+    renderColor: function(color) {
+      return (
+        <a key={color.id || color.cid} className="list-group-item">
+          {color.data.name}
+        </a>
+      );
+    },
+
+    render: function() {
+      var colors = this.props.colors;
+
+      return (
+        <div>
+          <h2>Color Requests</h2>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="What color should Guessatron display?"
+              value={this.state.newColor}
+              onKeyPress={this.onKeyDownNewColor}
+              onChange={this.onChangeNewColor} />
+                <span className="input-group-btn">
+                  <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                    Create
+                  </button>
+                </span>
+          </div>
+          <div className="list-group" style={{paddingTop: '16px'}}>
+            {colors.data.map(this.renderColor)}
+          </div>
+        </div>
+      );
+    }
+  })
+);

--- a/packages/lore-generate-tutorial/templates/step9/src/components/Color.js
+++ b/packages/lore-generate-tutorial/templates/step9/src/components/Color.js
@@ -1,0 +1,19 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: 'Color',
+
+  propTypes: {
+    color: React.PropTypes.object.isRequired
+  },
+
+  render: function () {
+    var color = this.props.color;
+
+    return (
+      <a className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+});

--- a/packages/lore-generate-tutorial/templates/step9/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/step9/src/components/ColorCreator.js
@@ -1,0 +1,84 @@
+var React = require('react');
+var Color = require('./Color');
+
+var ENTER_KEY = 13;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      colors: getState('color.find')
+    }
+  },
+  React.createClass({
+    displayName: 'ColorCreator',
+
+    propTypes: {
+      colors: React.PropTypes.object.isRequired
+    },
+
+    getInitialState: function () {
+      return {
+        newColor: ''
+      };
+    },
+
+    onChangeNewColor: function (event) {
+      this.setState({
+        newColor: event.target.value
+      });
+    },
+
+    onKeyDownNewColor: function (event) {
+      if (event.charCode !== ENTER_KEY) {
+        return;
+      }
+      this.onCreateColor();
+    },
+
+    onCreateColor: function() {
+      var value = this.state.newColor.trim();
+
+      if (value) {
+        lore.actions.color.create({
+          name: value
+        });
+
+        this.setState({
+          newColor: ''
+        });
+      }
+    },
+
+    renderColor: function(color) {
+      return (
+        <Color key={color.id || color.cid} color={color}/>
+      );
+    },
+
+    render: function() {
+      var colors = this.props.colors;
+
+      return (
+        <div>
+          <h2>Color Requests</h2>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="What color should Guessatron display?"
+              value={this.state.newColor}
+              onKeyPress={this.onKeyDownNewColor}
+              onChange={this.onChangeNewColor} />
+                <span className="input-group-btn">
+                  <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+                    Create
+                  </button>
+                </span>
+          </div>
+          <div className="list-group" style={{paddingTop: '16px'}}>
+            {colors.data.map(this.renderColor)}
+          </div>
+        </div>
+      );
+    }
+  })
+);

--- a/packages/lore-generate-tutorial/test/test.spec.js
+++ b/packages/lore-generate-tutorial/test/test.spec.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('an empty spec', function() {
+  it('passes', function() {
+    expect(true).to.eq(true);
+  });
+});

--- a/packages/lore-generate/src/helpers/file/index.js
+++ b/packages/lore-generate/src/helpers/file/index.js
@@ -14,10 +14,14 @@ module.exports = function(options) {
 
     var rootPath = path.resolve(process.cwd(), options.rootPath);
 
-    return fs.existsAsync(rootPath).then(function() {
-      return fs.outputFileAsync(rootPath, options.contents)
-    }).catch(function(err) {
-      throw new Error('Something else already exists at ::' + rootPath);
-    });
+    if (options.overwriteFiles) {
+      return fs.outputFileAsync(rootPath, options.contents);
+    } else {
+      return fs.existsAsync(rootPath).then(function() {
+        return fs.outputFileAsync(rootPath, options.contents)
+      }).catch(function(err) {
+        throw new Error('Something else already exists at ::' + rootPath);
+      });
+    }
   });
 };


### PR DESCRIPTION
This PR addresses #75.  It creates a new generator (`lore-generate-tutorial`) that is responsible for copying files for the tutorial into a users project.

This generator currently contains 14 steps, which covers:
1. Creating a project
2. Modifying index.html
3. Modifying routes
4. Creating data
5. Connecting components to the data store
6. Routing
7. Getting data based on route parameters

There will be a part 2 to this tutorial that will covers:
1. Editing data
2. Deleting data
3. Launching dialogs
4. Detecting when data can't be found (404) and displaying a meaningful message to the user
#### Usage

``` sh
lore new lore-example
lore generate:tutorial step1
lore generate:tutorial step2
lore generate:tutorial step3
...
```
#### Notes

Also added the ability for a generator to specify that it wants to overwrite existing files by setting `scope.overwriteFiles = true`.  There is probably a better name for that, like isForcedWrite or shouldForceWrite, something that semantically indicates it's a boolean value.  Also note sure I like that it's attached to scope...it seems more like an option.  Should look at that as part of the effort to improve the CLI (like adding colored output, or possibly providing an ability to let the user confirm overwriting files if they already exist and the action isn't being forced by the generator).

Hmm...actually, a better interface might be to pass in a force option to the CLI, like `lore generate:model Color --force`
