### PR TITLE
pass environment to config

### DIFF
--- a/packages/lore/src/app/getConfig.js
+++ b/packages/lore/src/app/getConfig.js
@@ -22,8 +22,8 @@ function getDefaultConfig(hooks) {
  * passed object, and builds a state object with the same shape.
  */
 
-module.exports = function getConfig(configOverride, hooks) {
+module.exports = function getConfig(configOverride, hooks, env) {
   var defaultConfig = getDefaultConfig(hooks);
-  var userConfig = configLoader.load();
+  var userConfig = configLoader.load(env);
   return _.merge({}, defaultConfig, userConfig, configOverride);
 };

--- a/packages/lore/src/app/index.js
+++ b/packages/lore/src/app/index.js
@@ -64,7 +64,7 @@ _.extend(Lore.prototype, {
     // Generate the final config from the combination of the overrides passed
     // into the app, the default config (calculated from the hooks), and the
     // user config for the project (loaded and compiled inside this function)
-    this.config = getConfig(configOverride, this.hooks);
+    this.config = getConfig(configOverride, this.hooks, this.environment);
 
     // Get initializers and run them
     this.initializers = getInitializers();


### PR DESCRIPTION
@jchansen @bringking @mikrofusion This unblocks storcery by resolving the allows me to get to environment specific vars by setting them on `development.js` and using `lore.config.WHATEVER`.
