### PR TITLE
added es7 version of connect behind the decorator flag

### DIFF
--- a/packages/lore-generate-component/src/index.js
+++ b/packages/lore-generate-component/src/index.js
@@ -3,27 +3,30 @@ var path = require('path');
 module.exports = {
 
   name: 'lore-generate-component',
-	moduleDir: require('path').resolve(__dirname, '..'),
-	templatesDirectory: require('path').resolve(__dirname,'../templates'),
-	before: require('./before'),
-	after: require('./after'),
-	targets: function(scope) {
+  moduleDir: require('path').resolve(__dirname, '..'),
+  templatesDirectory: require('path').resolve(__dirname, '../templates'),
+  before: require('./before'),
+  after: require('./after'),
+  targets: function ( scope ) {
     var isES6 = scope.options.indexOf('--es6') >= 0;
+    var useDecorator = scope.options.indexOf('--decorator') >= 0;
     var hasConnect = scope.options.indexOf('--connect') >= 0;
     var hasRouter = scope.options.indexOf('--router') >= 0;
     var template = './component';
 
-    if (isES6) {
+    if ( useDecorator ) {
+      template += '.es7'
+    } else if ( isES6 ) {
       template += '.es6'
     } else {
       template += '.es5'
     }
 
-    if (hasConnect) {
+    if ( hasConnect ) {
       template += '.connect'
     }
 
-    if (hasRouter) {
+    if ( hasRouter ) {
       template += '.router'
     }
 
@@ -31,7 +34,7 @@ module.exports = {
 
     var result = {};
     var componentLocation = './src/components/' + scope.componentName + '.js';
-    result[componentLocation] = { template: template};
+    result[componentLocation] = { template: template };
     return result;
   }
 };

--- a/packages/lore-generate-component/templates/component.es7.connect.js
+++ b/packages/lore-generate-component/templates/component.es7.connect.js
@@ -1,0 +1,33 @@
+import React, { Component, PropTypes } from 'react';
+
+@lore.connect((getState, props) => {
+  return {
+    //models: getState('model.find')
+  };
+})
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+  super(props);
+
+  // Set your initial state here
+  // this.setState = {};
+
+  // Bind your custom methods so you can access the expected 'this'
+  // this.myCustomMethod = this.myCustomMethod.bind(this);
+}
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {
+  //models: React.PropTypes.object.isRequired
+};
+
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = <%= componentName %>

--- a/packages/lore-generate-component/templates/component.es7.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es7.connect.router.js
@@ -1,0 +1,32 @@
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * IMPORTANT!!
+ *
+ * The template for ES7 components does not currently support react-router integration.
+ * This template will be updated as soon a solution is in place.
+ */
+class <%= componentName %> extends Component {
+
+  constructor(props) {
+  super(props);
+
+  // Set your initial state here
+  // this.setState = {};
+
+  // Bind your custom methods so you can access the expected 'this'
+  // this.myCustomMethod = this.myCustomMethod.bind(this);
+}
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+<%= componentName %>.propTypes = {};
+
+// NOTE: Please see https://github.com/lore/lore/issues/71 for a discussion
+// about why this template is not yet using the ES6 'export' syntax.
+module.exports = <%= componentName %>;


### PR DESCRIPTION
This PR adds the es7 version of a connected component behind the "decorator" flag, which takes precedence over the es6 version. The decorator flag was chosen since "decorators" are not necessarily in es7, but are assumed to be in es"whatever".  Fixes issue #58