### PR TITLE
Allow headers (and other configs) to pass to sync

### DIFF
--- a/packages/lore-models/src/sync.js
+++ b/packages/lore-models/src/sync.js
@@ -1,6 +1,7 @@
 import {type} from "./constants";
 import axios from "axios";
-import result from "lodash.result";
+import _assign from "lodash.assign";
+import _result from "lodash.result";
 
 /**
  * The lore.models "sync" function does all the heavy lifting of communicating with the server
@@ -10,7 +11,7 @@ import result from "lodash.result";
  */
 export default function sync( method, model, options = {} ) {
 
-  //build our params
+  //get our url
   let params = {type: method, url: options['url'] || model['url']};
 
   //check for URL
@@ -18,30 +19,21 @@ export default function sync( method, model, options = {} ) {
     throw new Error("An url must be provided in the model or the options for lore.models.sync")
   }
 
-  //determine the correct XHR type
-  let xhr;
-  switch ( params.type ) {
-    case type.GET:
-      xhr = axios.get;
-      break;
-    case type.POST:
-      xhr = axios.post;
-      break;
-    case type.PUT:
-      xhr = axios.put;
-      break;
-    case type.DELETE:
-      xhr = axios.delete;
-      break;
-  }
-
-  //add a payload for PUT and POST requests
+  //create a payload for PUT and POST requests
   let payload;
   if ( params.type === type.POST || params.type === type.PUT ) {
     payload = options.attrs || model.toJSON(options);
   }
 
-  //make the naive call
-  return xhr(result(params, 'url'), payload);
+  //build config object
+  let config = {
+    url: _result(params, 'url'),
+    method: params.type,
+    headers: options.headers,
+    data: payload
+  }
+
+  //override config with passed in options
+  return axios(_assign(config, options));
 
 };

--- a/packages/lore-models/test/sync.js
+++ b/packages/lore-models/test/sync.js
@@ -1,11 +1,52 @@
 import {expect} from "chai";
 import sync from "../src/sync";
 import {type} from "../src/constants";
+import nock from "nock";
 
 describe('#sync', () => {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  it("should throw an error if no URL is provided in the model or the options", ()=> {
-    expect(sync.bind(null, type.GET, {}, {})).to.throw(Error);
-  })
+  describe('with no url :(', () => {
+    it("should throw an error if no URL is provided in the model or the options", ()=> {
+      expect(sync.bind(null, type.GET, {}, {})).to.throw(Error);
+    })
+  });
 
+  describe('when options are passed in', () => {
+    describe('when headers are provided', () => {
+      beforeEach(() => {
+        nock('http://example.com', {
+          reqheaders:{
+            foobar: 'baz'
+          }
+        })
+        .persist()
+        .get('/')
+        .reply(200, [{success: true}]);
+      });
+
+      it("should set headers ", ()=> {
+        return sync(type.GET, {}, {url: 'http://example.com', headers:{foobar:'baz'}})
+      })
+    });
+
+    describe('when other config options are provided', () => {
+      beforeEach(() => {
+        nock('http://example.com', {
+          reqheaders:{
+            'x-xsrf-token': 'token'
+          }
+        })
+        .persist()
+        .post('/')
+        .reply(200, [{success: true}]);
+      });
+
+      it("should set options ", ()=> {
+        return sync(type.POST, {}, {url: 'http://example.com', attrs:{param: 'value'}, headers: {'X-XSRF-TOKEN': 'token'}, xsrfHeaderName: 'X-XSRF-TOKEN'})
+      })
+    });
+  });
 });


### PR DESCRIPTION
I need to pass headers to `sync` so I could send in an auth token.  Once I started down this path, I realized that there a bunch of other `axios` configuration options (https://github.com/mzabriskie/axios#request-config) that we may want to pass in as well so I extended the 'setting header' approach to set :exclamation:any:exclamation: axios options that the user wants to send in.

I also refactored `sync` to use the more generic `config` object approach to create an axios object versus the `GET`, `POST`, `PUT`, `DELETE` case statement so that we can support other methods if needed.

![screen shot 2016-04-07 at 12 58 58 pm](https://cloud.githubusercontent.com/assets/5195704/14365061/92c99726-fcc0-11e5-9193-1442c25ac030.png)
