### PR TITLE
[lore-cli] remove errors during new project generation

### DIFF
--- a/packages/lore-generate-new/src/before.js
+++ b/packages/lore-generate-new/src/before.js
@@ -24,7 +24,7 @@ module.exports = function(scope) {
     if(fs.existsSync(scope.rootPath)) {
       var files = fs.readdirSync(scope.rootPath);
       if (files.length > 0) {
-        throw new Error('Couldn\'t create a new Lore app in "'+scope.rootPath+'" (directory already exists and is not empty)');
+        throw new Error("Couldn't create a new Lore app in '" + scope.rootPath + "' (directory already exists and is not empty)");
       }
     }
   });

--- a/packages/lore-generate-new/src/index.js
+++ b/packages/lore-generate-new/src/index.js
@@ -12,6 +12,7 @@ module.exports = {
 	targets: function(scope) {
     return {
 
+      // root
       './.editorconfig': { copy: 'editorconfig.template' },
       './.gitignore': { copy: 'gitignore' },
       './index.html': { copy: 'index.html' },
@@ -24,46 +25,45 @@ module.exports = {
       './server.js': { copy: 'server.js' },
       './webpack.config.js': { copy: 'webpack.config.js' },
 
-      './webpack': { folder: {}},
-      './webpack/env': { folder: {}},
+      // webpack
       './webpack/config.js': { copy: 'webpack/config.js'},
       './webpack/README.md': { copy: 'webpack/README.md'},
       './webpack/env/development.js': { copy: 'webpack/env/development.js'},
       './webpack/env/production.js': { copy: 'webpack/env/production.js'},
       './webpack/env/README.md': { copy: 'webpack/env/README.md'},
 
-      './src': { folder: {}},
+      // src
       './src/README.md': { copy: 'src/README.md'},
 
-      './src/actions': { folder: {}},
+      // actions
       './src/actions/README.md': { copy: 'src/actions/README.md'},
 
-      './src/collections': { folder: {}},
+      // collections
       './src/collections/README.md': { copy: 'src/collections/README.md'},
 
-      './src/components': { folder: {}},
+      // components
       './src/components/README.md': { copy: 'src/components/README.md'},
       './src/components/Layout.js': { copy: 'src/components/Layout.js'},
       './src/components/Master.js': { copy: 'src/components/Master.js'},
 
-      './src/constants': { folder: {}},
+      // constants
       './src/constants/README.md': { copy: 'src/constants/README.md'},
       './src/constants/ActionTypes.js': { copy: 'src/constants/ActionTypes.js'},
       './src/constants/PayloadStates.js': { copy: 'src/constants/PayloadStates.js'},
 
-      './src/dialogs': { folder: {}},
+      // dialogs
       './src/dialogs/.gitkeep': { copy: '.gitkeep'},
 
-      './src/mixins': { folder: {}},
+      // mixins
       './src/mixins/.gitkeep': { copy: '.gitkeep'},
 
-      './src/models': { folder: {}},
+      // mixins
       './src/models/README.md': { copy: 'src/models/README.md'},
 
-      './src/reducers': { folder: {}},
+      // reducers
       './src/reducers/README.md': { copy: 'src/reducers/README.md'},
 
-      './config': { folder: {}},
+      // config
       './config/actionBlueprints.js': { copy: 'config/actionBlueprints.js'},
       './config/actions.js': { copy: 'config/actions.js'},
       './config/collections.js': { copy: 'config/collections.js'},
@@ -78,17 +78,16 @@ module.exports = {
       './config/router.js': { copy: 'config/router.js'},
       './config/README.md': { copy: 'config/README.md'},
 
-      './config/env': { folder: {}},
+      // config/env
       './config/env/development.js': { copy: 'config/env/development.js'},
       './config/env/production.js': { copy: 'config/env/production.js'},
       './config/env/README.md': { copy: 'config/env/README.md'},
 
-      './gulp': { folder: {}},
-      './gulp/tasks': { folder: {}},
+      // gulp
       './gulp/tasks/default.js': { copy: 'gulp/tasks/default.js'},
       './gulp/tasks/README.md': { copy: 'gulp/tasks/README.md'},
 
-      './initializers': { folder: {}},
+      // initializers
       './initializers/REAMDE.md': { copy: 'initializers/README.md'}
 
     };

--- a/packages/lore-generate/src/generate.js
+++ b/packages/lore-generate/src/generate.js
@@ -20,7 +20,9 @@ module.exports = generate = function(Generator, scope) {
       var target = targets[keyPath];
       var err;
 
-      if (!target) throw new Error('Generator error: Invalid target: {"' + keyPath + '": ' + util.inspect(target) + '}');
+      if (!target) {
+        throw new Error('Generator error: Invalid target: {"' + keyPath + '": ' + util.inspect(target) + '}');
+      }
 
       var targetScope = _.merge({}, scope, {
         rootPath: path.resolve(scope.rootPath, keyPath),


### PR DESCRIPTION
This PR removes the errors that occur during new project generation when running `lore new my-app`. They look like this:

```
Generator finished successfully.
[Error: Something else already exists at ::/Users/jchansen/lore-tutorial/webpack]
[Error: Something else already exists at ::/Users/jchansen/lore-tutorial/webpack/env]
[Error: Something else already exists at ::/Users/jchansen/lore-tutorial/src]
[Error: Something else already exists at ::/Users/jchansen/lore-tutorial/src/actions]
...
```

The errors occur because the CLI generator used to require that folders be created explicitly, but was refactored to use a different approach that created folders automatically. But with the new approach, creating a folder explicitly causes an error. Fix is to stop creating folders, and let them be created automatically.