### PR TITLE
[lore] make port for webpack dev server configurable

### DIFF
--- a/packages/lore-generate-github/generator.js
+++ b/packages/lore-generate-github/generator.js
@@ -21,7 +21,6 @@ module.exports = Generator.extend({
         'gulp-sequence@0.4.5',
         'gulp-gh-pages@0.5.4',
         'gulp-util@3.0.7',
-        'yargs@4.2.0',
         '--save-dev'
       ], {
         stdio: 'inherit'

--- a/packages/lore-generate-new/templates/package.json
+++ b/packages/lore-generate-new/templates/package.json
@@ -43,7 +43,8 @@
     "redux-devtools": "2.1.5",
     "style-loader": "0.13.0",
     "webpack": "1.10.5",
-    "webpack-dev-server": "1.10.1"
+    "webpack-dev-server": "1.10.1",
+    "yargs": "^4.7.1"
   }
 }
 

--- a/packages/lore-generate-new/templates/server.js
+++ b/packages/lore-generate-new/templates/server.js
@@ -12,6 +12,18 @@
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
+var url = require('url');
+var _ = require('lodash');
+
+function getDevServerPort() {
+  var devServerEntry = _.find(config.entry, function(entry) {
+    return entry.indexOf('webpack-dev-server/client?') === 0;
+  });
+  var devServer = devServerEntry.split('?')[1];
+  return url.parse(devServer).port;
+}
+
+var PORT = getDevServerPort();
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
@@ -20,10 +32,10 @@ new WebpackDevServer(webpack(config), {
   stats: {
     colors: true
   }
-}).listen(3000, 'localhost', function (err) {
+}).listen(PORT, 'localhost', function (err) {
   if (err) {
     console.log(err);
   }
 
-  console.log('Listening at localhost:3000');
+  console.log('Listening at localhost:' + PORT);
 });

--- a/packages/lore-generate-new/templates/webpack.config.js
+++ b/packages/lore-generate-new/templates/webpack.config.js
@@ -21,9 +21,11 @@
 var requireDir = require('require-dir');
 var _ = require('lodash');
 var envConfigs = requireDir('./webpack/env');
+var yargs = require('yargs');
 
 var settings = {
-  APP_ROOT: __dirname
+  APP_ROOT: __dirname,
+  PORT: yargs.argv.port || 3000
 };
 
 // build the base webpack config

--- a/packages/lore-generate-new/templates/webpack/env/development.js
+++ b/packages/lore-generate-new/templates/webpack/env/development.js
@@ -10,10 +10,11 @@ var webpack = require('webpack');
 
 module.exports = function(settings) {
   var APP_ROOT = settings.APP_ROOT;
+  var PORT = settings.PORT;
 
   return {
     entry: [
-      'webpack-dev-server/client?http://localhost:3000',
+      'webpack-dev-server/client?http://localhost:' + PORT,
       'webpack/hot/only-dev-server',
       './index'
     ],

--- a/packages/lore-generate-surge/generator.js
+++ b/packages/lore-generate-surge/generator.js
@@ -21,7 +21,6 @@ module.exports = Generator.extend({
         'gulp-sequence@0.4.5',
         'gulp-surge@0.1.0',
         'gulp-util@3.0.7',
-        'yargs@4.2.0',
         '--save-dev'
       ], {
         stdio: 'inherit'


### PR DESCRIPTION
This PR makes the port the development server runs on configurable.  By default the dev server runs on port 300, but now it runs on whatever you want it to.

### Usage
If you run `npm start` it runs `node server` without any arguments, which causes the dev server to start up on it's default port 300.

But if you run `node server --port=2001`, it will cause the dev server to start up on port 2001.

If you don't like passing in command line arguments, and would prefer to permanently change the default, you can do so by modifying this line in `webpack.config.js`:

```
var yargs = require('yargs');

var settings = {
  APP_ROOT: __dirname,
  PORT: yargs.argv.port || 3000 // <= change me to change default
};
```

### Approach
It uses [yargs](http://yargs.js.org/) to parse the command line options and extract the port option if one was provided.