### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 Convention driven framework for React + Redux applications. Heavily opinionated and highly respectful. Built on 
 React, Webpack, Redux and React-Router.
 
-### NOT RECOMMENDED FOR PRODUCTION
-**PLEASE NOTE**: Lore is not currently recommended for use in production. It is still in active development, and 
-among other reasons, does not yet have built in support for pagination (coming soon). Additionally, the project does not 
-yet support a dedicated ES6 experience, which we know many of you will prefer (also coming soon).
 
 ### Orientation
 


### PR DESCRIPTION
Update readme to remove blurb about production usage. I think that using semver is enough of a warning to people that this is obviously not a 1.0, and  knowing what we know about semver, we will responsibly introduce changes. Let them decide if they want to use it for production. Main point, React was heavily used in production before 1.0. Thoughts?