### PR TITLE
Fix bug with wrong file reference in lore-generate-tutorial-server

### DIFF
--- a/packages/lore-generate-tutorial-server/generator.js
+++ b/packages/lore-generate-tutorial-server/generator.js
@@ -75,7 +75,7 @@ module.exports = Generator.extend({
       'views/homepage.ejs',
       'views/layout.ejs',
       '.editorconfig',
-      '.gitignore',
+      '.npmignore',
       '.sailsrc',
       'app.js',
       'package.json',


### PR DESCRIPTION
`lore-generate-tutorial-server`'s target file list had `.gitignore`, but should be `.npmignore`.