### PR TITLE
[lore] upgrade react-router from v1 to v2

### DIFF
--- a/packages/lore-generate-component/templates/component.es5.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.router.js
@@ -6,21 +6,12 @@ module.exports = lore.connect(function(getState, props) {
       //models: getState('model.find')
     }
   },
-  React.createClass({
+  Router.withRouter(React.createClass({
     displayName: '<%= componentName %>',
 
-    /**
-     * This mixin provides a 'history' object on 'this'.
-     * To navigate to a new route, call it like this:
-     * this.history.pushState(null, '/the/new/url');
-     *
-     * Learn more about routing and the history object at:
-     * https://github.com/reactjs/react-router/blob/v1.0.3/docs/API.md#history-mixin
-     */
-    mixins: [Router.History],
-
     propTypes: {
-      //models: React.PropTypes.object.isRequired
+      //models: React.PropTypes.object.isRequired,
+      router: React.PropTypes.object.isRequired
     },
 
     render: function () {
@@ -28,5 +19,5 @@ module.exports = lore.connect(function(getState, props) {
         <div></div>
       );
     }
-  })
+  }))
 );

--- a/packages/lore-generate-component/templates/component.es5.router.js
+++ b/packages/lore-generate-component/templates/component.es5.router.js
@@ -1,24 +1,16 @@
 var React = require('react');
 var Router = require('react-router');
 
-module.exports = React.createClass({
+module.exports = Router.withRouter(React.createClass({
   displayName: '<%= componentName %>',
 
-  /**
-   * This mixin provides a 'history' object on 'this'.
-   * To navigate to a new route, call it like this:
-   * this.history.pushState(null, '/the/new/url');
-   *
-   * Learn more at:
-   * https://github.com/reactjs/react-router/blob/v1.0.3/docs/API.md#history-mixin
-   */
-  mixins: [Router.History],
-
-  propTypes: {},
+  propTypes: {
+    router: React.PropTypes.object.isRequired
+  },
 
   render: function () {
     return (
       <div></div>
     );
   }
-});
+}));

--- a/packages/lore-generate-component/templates/component.es6.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.router.js
@@ -1,11 +1,6 @@
 import React, { Component, PropTypes } from 'react';
+import { Link, withRouter } from 'react-router';
 
-/**
- * IMPORTANT!!
- *
- * The template for ES6 components does not currently support react-router integration.
- * This template will be updated as soon a solution is in place.
- */
 class <%= componentName %> extends Component {
 
   constructor(props) {
@@ -25,6 +20,13 @@ class <%= componentName %> extends Component {
   }
 }
 
-<%= componentName %>.propTypes = {};
+<%= componentName %>.propTypes = {
+  //models: React.PropTypes.object.isRequired,
+  router: React.PropTypes.object.isRequired
+};
 
-export default <%= componentName %>;
+export default lore.connect((getState, props) => {
+  return {
+    //models: getState('model.find')
+  };
+}, withRouter(<%= componentName %>));

--- a/packages/lore-generate-component/templates/component.es6.router.js
+++ b/packages/lore-generate-component/templates/component.es6.router.js
@@ -1,11 +1,6 @@
 import React, { Component, PropTypes } from 'react';
+import { Link, withRouter } from 'react-router';
 
-/**
- * IMPORTANT!!
- *
- * The template for ES6 components does not currently support react-router integration.
- * This template will be updated as soon a solution is in place.
- */
 class <%= componentName %> extends Component {
 
   constructor(props) {
@@ -25,6 +20,8 @@ class <%= componentName %> extends Component {
   }
 }
 
-<%= componentName %>.propTypes = {};
+<%= componentName %>.propTypes = {
+  router: React.PropTypes.object.isRequired
+};
 
-export default <%= componentName %>;
+export default withRouter(<%= componentName %>);

--- a/packages/lore-generate-new/templates/es5/config/env/development.js
+++ b/packages/lore-generate-new/templates/es5/config/env/development.js
@@ -2,11 +2,11 @@
  * Development environment settings
  *
  * This file is where you define overrides for any of the config settings when operating under the development
- * environment. Development environment is defined as `NODE_ENV=development` or the absense of an `NODE_ENV` environment
+ * environment. Development environment is defined as `NODE_ENV=development` or the absence of an `NODE_ENV` environment
  * variable.
  **/
 
-// var createBrowserHistory = require('history/lib/createBrowserHistory');
+// var browserHistory = require('react-router').browserHistory;
 
 module.exports = {
 
@@ -21,7 +21,7 @@ module.exports = {
   // },
 
   // router: {
-  //   history: createBrowserHistory()
+  //   history: browserHistory
   // }
 
 };

--- a/packages/lore-generate-new/templates/es5/config/router.js
+++ b/packages/lore-generate-new/templates/es5/config/router.js
@@ -4,17 +4,17 @@
  * history or push state).
  **/
 
-var createBrowserHistory = require('history/lib/createBrowserHistory');
+var browserHistory = require('react-router').browserHistory;
 
 module.exports = {
 
-  /****************************************************************************
-  *                                                                           *
-  * Whether browser should use pushState or hash to keep track of routes      *
-  * See: https://github.com/rackt/history                                     *
-  *                                                                           *
-  ****************************************************************************/
+  /************************************************************************************
+  *                                                                                   *
+  * Whether browser should use pushState or hash to keep track of routes              *
+  * See: https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md *
+  *                                                                                   *
+  *************************************************************************************/
 
-  history: createBrowserHistory()
+  history: browserHistory
 
 };

--- a/packages/lore-generate-new/templates/es5/package.json
+++ b/packages/lore-generate-new/templates/es5/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "classnames": "2.1.3",
-    "history": "1.17.0",
     "invariant": "2.1.0",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
@@ -20,7 +19,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.1",
-    "react-router": "1.0.3",
+    "react-router": "^2.0.0",
     "react-tap-event-plugin": "^1.0.0",
     "redux": "^3.0.2",
     "redux-thunk": "^2.0.1",

--- a/packages/lore-generate-new/templates/es6/config/env/development.js
+++ b/packages/lore-generate-new/templates/es6/config/env/development.js
@@ -2,11 +2,11 @@
  * Development environment settings
  *
  * This file is where you define overrides for any of the config settings when operating under the development 
- * environment. Development environment is defined as `NODE_ENV=development` or the absense of an `NODE_ENV` environment 
+ * environment. Development environment is defined as `NODE_ENV=development` or the absence of an `NODE_ENV` environment
  * variable.
  **/
 
-// import createBrowserHistory from 'history/lib/createBrowserHistory'
+// import { browserHistory } from 'react-router';
 
 export default {
 
@@ -21,7 +21,7 @@ export default {
   // },
 
   // router: {
-  //   history: createBrowserHistory()
+  //   history: browserHistory
   // }
 
 }

--- a/packages/lore-generate-new/templates/es6/config/router.js
+++ b/packages/lore-generate-new/templates/es6/config/router.js
@@ -4,18 +4,17 @@
  * history or push state).
  **/
 
-
-import createBrowserHistory from 'history/lib/createBrowserHistory';
+import { browserHistory } from 'react-router';
 
 export default {
 
-  /****************************************************************************
-  *                                                                           *
-  * Whether browser should use pushState or hash to keep track of routes      *
-  * See: https://github.com/rackt/history                                     *
-  *                                                                           *
-  ****************************************************************************/
+  /************************************************************************************
+  *                                                                                   *
+  * Whether browser should use pushState or hash to keep track of routes              *
+  * See: https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md *
+  *                                                                                   *
+  *************************************************************************************/
 
-  history: createBrowserHistory()
+  history: browserHistory
 
 }

--- a/packages/lore-generate-new/templates/es6/package.json
+++ b/packages/lore-generate-new/templates/es6/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "classnames": "2.1.3",
-    "history": "1.17.0",
     "invariant": "2.1.0",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
@@ -20,7 +19,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.1",
-    "react-router": "1.0.3",
+    "react-router": "^2.0.0",
     "react-tap-event-plugin": "^1.0.0",
     "redux": "^3.0.2",
     "redux-thunk": "^2.0.1",

--- a/packages/lore/package.json
+++ b/packages/lore/package.json
@@ -44,14 +44,13 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
-    "history": "^1.17.0",
     "json-loader": "0.5.4",
     "mocha": "2.3.4",
     "nock": "2.6.0",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-router": "^1.0.3",
+    "react-router": "^2.0.0",
     "redux": "^3.0.2",
     "redux-thunk": "^2.0.1",
     "rimraf": "2.5.2",
@@ -62,7 +61,7 @@
     "json-loader": "0.5.4",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-router": "^1.0.3",
+    "react-router": "^2.0.0",
     "redux": "^3.0.2"
   }
 }


### PR DESCRIPTION
This PR upgrades `react-router` from v1 to v2 and resolves #65 and #71.

#### Changes
For `lore` and the new project templates in `lore-generate-new`, the only relevant change is the removal of `history` in favor of using the built-in history singletons provided by `react-router`, such as `hashHistory` and `browserHistory`.

For the ES5 and ES6 component generators in `lore-generate-component`, this PR uses the `v2.4.x` version of `react-router` that supplies a HoC (higher order component) that automatically extracts router from context and passes it in through props (yay for HoCs).


