### PR TITLE
Add Pagination Example

### DIFF
--- a/examples/pagination/.editorconfig
+++ b/examples/pagination/.editorconfig
@@ -1,0 +1,26 @@
+##
+# .editorconfig
+#
+# This file declares project configurations settings like indentation
+# (tabs vs spaces), indentation size, and whether to trim trailing whitespace
+# at the end of file lines.
+#
+# This file is useful as a way to agnostically declare project settings, as it
+# can be consumed and applied by a wide variety of IDEs, text editors and
+# command line editing programs.  For example, if you write code in WebStorm,
+# the IDE will automatically see this file and apply the settings, so you 
+# don't have to worry about whether the code you're writing adheres to project
+# settings.
+#
+# editorconfig.org
+##
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/examples/pagination/.gitignore
+++ b/examples/pagination/.gitignore
@@ -1,0 +1,24 @@
+##
+# This file specifies which project files should be kept out of version
+# control if you are using git. It includes things like code coverage reports,
+# npm installation error files, your config/local.js file, IDE specific files
+# and more.
+#
+# Feel free to add and remove things from this file as you see fit.
+##
+
+node_modules
+bower_components
+config/local.js
+lib-cov
+*.seed
+*.log
+*.out
+*.pid
+npm-debug.log
+*~
+*#
+.DS_STORE
+.idea
+.node_history
+

--- a/examples/pagination/.lorerc
+++ b/examples/pagination/.lorerc
@@ -1,0 +1,6 @@
+{
+  "generators": {
+    "language": "es5"
+  },
+  "hooks": {}
+}

--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -1,0 +1,3 @@
+# pagination
+
+A [Lore](http://www.lorejs.org) application.

--- a/examples/pagination/config/README.md
+++ b/examples/pagination/config/README.md
@@ -1,0 +1,10 @@
+# Config
+
+This folder contains all of the configuration settings for lore.
+
+The final configuration for Lore is determined as follows:
+
+1. **Build the config object** - A configuration object is built from everything in /config (excluding /dev an local.js)
+2. **Apply environent specific settings** - The appropriate environment config is pulled from /env and overrides any config options previously
+specified.
+3. **Apply any settings in local.js** - Local.js is examined, and any config options specified there will override anything previously.

--- a/examples/pagination/config/actionBlueprints.js
+++ b/examples/pagination/config/actionBlueprints.js
@@ -1,0 +1,17 @@
+/**
+ * Configuration file for action blueprints
+ *
+ * This file is where you define overrides for the default action blueprints.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * No options currently exist, however this will eventually allow you to     *
+  * specify whether blueprints should be on or off, and which actions should  *
+  * have them all, which should only have some, and which should have none    *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/actions.js
+++ b/examples/pagination/config/actions.js
@@ -1,0 +1,15 @@
+/**
+ * Configuration file for actions
+ *
+ * This file is where you define overrides for the default action behaviors.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * No options currently exist                                                *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/collections.js
+++ b/examples/pagination/config/collections.js
@@ -1,0 +1,29 @@
+/**
+ * Configuration file for collections
+ *
+ * This file is where you define overrides for the default collection behaviors.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * Define properties that should apply to all collections here. Since we     *
+  * only lightly wrapping Backbone, you can define any properties here that   *
+  * Backbone supports for Collections.                                        *
+  * See: http://backbonejs.org/#Collection                                    *
+  *                                                                           *
+  ****************************************************************************/
+
+  properties: {
+
+    //
+    // See http://backbonejs.org/#Collection-parse
+    //
+    // parse: function(attributes) {
+    //   return attributes;
+    // }
+
+  }
+
+};

--- a/examples/pagination/config/connect.js
+++ b/examples/pagination/config/connect.js
@@ -1,0 +1,15 @@
+/**
+ * Configuration file for connect
+ *
+ * This file is where you define overrides for the default connect behavior.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * No options currently exist                                                *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/dialog.js
+++ b/examples/pagination/config/dialog.js
@@ -1,0 +1,18 @@
+/**
+ * Configuration file for dialogs
+ *
+ * This file is where you define overrides for the default dialog behavior.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * DOM Element ID that the dialogs should be mounted to. Should be located   *
+  * outside the DOM element the application is mounted to.                    *
+  *                                                                           *
+  ****************************************************************************/
+
+  // domElementId: 'dialog'
+
+};

--- a/examples/pagination/config/env/README.md
+++ b/examples/pagination/config/env/README.md
@@ -1,0 +1,3 @@
+# app/config/env
+
+This folder contains any environment specific overrides for the Lore config.

--- a/examples/pagination/config/env/development.js
+++ b/examples/pagination/config/env/development.js
@@ -1,0 +1,27 @@
+/**
+ * Development environment settings
+ *
+ * This file is where you define overrides for any of the config settings when operating under the development
+ * environment. Development environment is defined as `NODE_ENV=development` or the absence of an `NODE_ENV` environment
+ * variable.
+ **/
+
+// var browserHistory = require('react-router').browserHistory;
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * This file will override other config settings based on the environment    *
+  *                                                                           *
+  ****************************************************************************/
+
+  // models: {
+  //   apiRoot: 'https://api.example.dev'
+  // },
+
+  // router: {
+  //   history: browserHistory
+  // }
+
+};

--- a/examples/pagination/config/env/production.js
+++ b/examples/pagination/config/env/production.js
@@ -1,0 +1,16 @@
+/**
+ * Production environment settings
+ *
+ * This file is where you define overrides for any of the config settings when operating under the production 
+ * environment. Production environment is defined as `NODE_ENV=production`.
+ **/
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * This file will override other config settings based on the environment    *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/models.js
+++ b/examples/pagination/config/models.js
@@ -1,0 +1,51 @@
+/**
+ * Configuration file for models-collections
+ *
+ * This file is where you define overrides for the default model behaviors.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * Define properties that should apply to all collections here. Since we     *
+  * only lightly wrapping Backbone, you can define any properties here that   *
+  * Backbone supports for Collections.                                        *
+  *                                                                           *
+  ****************************************************************************/
+
+  apiRoot: 'https://api.github.com/search',
+
+  /****************************************************************************
+   *                                                                           *
+   * If pluralize is true, all model names will be converted to their plural   *
+   * form when making API calls. A model called 'foo' will made a call to      *
+   * '/foos' if pluralize is true, and to '/foo' if pluralize is false         *
+   * Uses the pluralize.js library to determine the plural model name          *
+   * See: https://github.com/blakeembrey/pluralize                             *
+   *                                                                           *
+   ****************************************************************************/
+
+  // pluralize: true,
+
+  /****************************************************************************
+  *                                                                           *
+  * Define properties that should apply to all models here. Since we are      *
+  * only lightly wrapping Backbone, you can define any properties here that   *
+  * Backbone supports for Models.                                             *
+  * See: http://backbonejs.org/#Model                                         *
+  *                                                                           *
+  ****************************************************************************/
+
+  properties: {
+
+    //
+    // See http://backbonejs.org/#Model-parse
+    //
+    // parse: function(attributes) {
+    //   return attributes;
+    // }
+
+  }
+
+};

--- a/examples/pagination/config/reducerActionMap.js
+++ b/examples/pagination/config/reducerActionMap.js
@@ -1,0 +1,103 @@
+/**
+ * Configuration file for the reducer-action map
+ *
+ * This file is where you define overrides for the default action-reducer map.
+ * Whenever you create a model in Lore, the conventions will automatically
+ * create a set of reducers and actions to support basic CRUD operations and
+ * lazy-loading of data from the server.  For example, if you create a model
+ * called `todo`, the default map is as follows:
+ *
+ *  Action         | ActionType  | Reducer
+ *  :------------- | :---------- | :------
+ *  todo.fetchAll  | FETCH_TODOS | todo.all
+ *  todo.fetch     | FETCH_TODO  | todo.byId
+ *
+ * To better understand the map, it helps to take a look at the typical usage
+ * for `lore.connect`).  Here we want to retrieve all the todos that have been
+ * created.
+ *
+ * lore.connect(function(getState, props) {
+ *   return {
+ *     todos: getState('todo.all', { where: {}})
+ *   }
+ * })
+ *
+ * What happens when `getState()` is called, is that it looks at the `todo.all`
+ * string, which represents the reducer that you want the data for.  Lore then
+ * looks at the state of that reducer at the time of the function call.  If the
+ * state for that reducer hasn't been initialized yet (no data has been fetched
+ * from the server) it will execute the action on the other side of the map.
+ * 
+ * So the first time you call `getState('todo.all')` the reducer won't any data
+ * in it.  So Lore will then call `actions.todo.fetchAll` to retrieve the list of
+ * todos.  Once the data comes back from the server (passing through whatever
+ * parse methods you've specified to transform the data), the action will package
+ * up the data and emit an action with an ActionType of `FETCH_TODOS`. This
+ * ActionType is something the `todo.all` reducer is configured to look for,
+ * and will then store the data, and the app will be notified that there is
+ * new data in the store.  The app will update, and your component will call
+ * `getState('todo.all')` again.  But this time Lore will see there *is* data
+ * in the reducer state, and so it will return it *without* calling the action
+ * this time.
+ * 
+ * ### Problems This Map Helps Address
+ * 
+ * 1. **Duplicate AJAX Calls** - if components declare the data they want, and an
+ * AJAX call is executed to fetch that data if it doesn't exist, then everytime
+ * the component renders there's the potential to make an AJAX request.  If
+ * guards aren't in place to know when an AJAX request is or isn't in flight,
+ * you can end up making multiple AJAX requests for the same data. Depending on
+ * the number of request and the rate that components update, this has the
+ * potential to severely degrade the usability of your application and apply
+ * unnecessary load to your API server.
+ * 
+ * 2. **Infinite Loop + Browser Crash** - A big motivation for establishing
+ * conventions around reducers and actions was due to how easy it can be to
+ * accidentally end up in an infinite loop in React/Redux in a lazy-loading
+ * setup like `lore.connect` is configured for (a setup where components declare
+ * the data they want and something else is responsible for fetching if it
+ * doesn't exist).  If a component requests state, like `todo.all`, and that
+ * state doesn't exist, an action will be triggered and the store will be updated
+ * to reflect the fact that data is being fetching, and the component will get
+ * updated because the reducer state changed.  Which will give it another
+ * opportunity to request `todo.all`.  At this point, there are 3 pieces that
+ * need to have been linked up properly in order to form a proper guard to prevent
+ * duplicate AJAX calls.  First, there needs to be a reducer called `todo.all`,
+ * then there needs to be an action called `todo.fetchAll`, and finally there
+ * needs to be an ActionType called `FETCH_TODOS` the the action emits and the
+ * reducer waits.  Without conventions, there's a lot of files that need to be
+ * copy/pasted to enable that data flow for every model/endpoint you need in
+ * your application.  If you accidentally `require()` the wrong file, or forget
+ * to make all the neccesary changes in your copy/pasted files, or forget to
+ * create the ActionType, or forget to make sure the correct ActionType is being
+ * emitted and listened for, the component may end up accessing the store again,
+ * finding no data, making a request, and updating the store, and getting called
+ * again, and accessing the store again, and finding no data, and making a
+ * request, and so on.  It's a conceptually simple bug to solve if you know what
+ * to look for, but can be incredibly time consuming to track down the first
+ * time you see if it you don't want to look for, and you have to manually
+ * force quit the browser tab when it happens.  This "little" problem can be
+ * draining, a huge blocker, and incredibly frustrating for other people working
+ * in your project. So a big reason for creating conventions around reducer and
+ * actions and setting up a map between them was to solve this problem.  This
+ * way the framework has the ability to guard against and limit certain
+ * situations (at least until you override the conventions).
+ **/
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * Add custom action-reducer maps here, or override existing ones            *
+  *                                                                           *
+  ****************************************************************************/
+
+  // 'todo.all': {
+  //   action: 'todo.fetchAll'
+  // },
+  //
+  // 'todo.byId': {
+  //   action: 'todo.fetch'
+  // }
+
+};

--- a/examples/pagination/config/reducerBlueprints.js
+++ b/examples/pagination/config/reducerBlueprints.js
@@ -1,0 +1,17 @@
+/**
+ * Configuration file for reducer blueprints
+ *
+ * This file is where you define overrides for the default reducer blueprints.
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * No options currently exist, however this will eventually allow you to     *
+  * specify whether blueprints should be on or off, and which reducers should *
+  * have them all, which should only have some, and which should have none    *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/reducers.js
+++ b/examples/pagination/config/reducers.js
@@ -1,0 +1,16 @@
+/**
+ * Configuration file for reducers
+ *
+ * This file is where you define overrides for the default reducer behaviors.
+ * TODO: figure out what options go here...
+ */
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * No options currently exist                                                *
+  *                                                                           *
+  ****************************************************************************/
+
+};

--- a/examples/pagination/config/redux.js
+++ b/examples/pagination/config/redux.js
@@ -1,0 +1,26 @@
+/**
+ * Configuration file for Redux
+ *
+ * This file is where you define overrides for the default redux behavior. Currently it only supports the ability to
+ * swap out the middleware that Lore uses by default, but we may provide a simply true/false toggle in the future for
+ * enabling the redux dev-tools if it makes sense.
+ */
+
+// var Redux = require('redux');
+// var applyMiddleware = Redux.applyMiddleware;
+// var thunk = require('redux-thunk');
+
+module.exports = {
+
+  /****************************************************************************
+  *                                                                           *
+  * Which middleware should be loaded for Redux                               *
+  * See: http://rackt.org/redux/docs/advanced/Middleware.html                 *
+  *                                                                           *
+  ****************************************************************************/
+
+  // middleware: [
+  //   applyMiddleware(thunk)
+  // ]
+
+};

--- a/examples/pagination/config/router.js
+++ b/examples/pagination/config/router.js
@@ -1,0 +1,20 @@
+ /**
+ * This file is where you define overrides for the default routing behavior.
+ * Currently this includes how you want your routing display (using hash
+ * history or push state).
+ **/
+
+var browserHistory = require('react-router').browserHistory;
+
+module.exports = {
+
+  /************************************************************************************
+  *                                                                                   *
+  * Whether browser should use pushState or hash to keep track of routes              *
+  * See: https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md *
+  *                                                                                   *
+  *************************************************************************************/
+
+  history: browserHistory
+
+};

--- a/examples/pagination/gulp/tasks/README.md
+++ b/examples/pagination/gulp/tasks/README.md
@@ -1,0 +1,20 @@
+# app/gulp/tasks
+
+### Purpose
+
+This is where you should put your gulp tasks. While webpack and npm scripts have gone a long way towards
+replacing the need for gulp on many projects, it can still be useful in scenarios like publishing your
+project to Surge or GitHub Pages.
+
+### Example
+
+Let's say you want to create a gulp task that welcomes someone to your project.  To do that you would create
+a file called `hello.js` in `/gulp/tasks` and execute it by typing `gulp say:hello`.
+
+```
+// file: hello.js
+
+gulp.task('say:hello', function () {
+  console.log('Hello! Nice to meet you : )');
+});
+```

--- a/examples/pagination/gulp/tasks/default.js
+++ b/examples/pagination/gulp/tasks/default.js
@@ -1,0 +1,6 @@
+var gulp = require('gulp');
+
+gulp.task('default', function () {
+  console.log('Hello! Nice to meet you : )');
+  console.log("I'm the default gulp task. You can override me with something more useful.");
+});

--- a/examples/pagination/gulpfile.js
+++ b/examples/pagination/gulpfile.js
@@ -1,0 +1,17 @@
+/*
+  gulpfile.js
+  ===========
+  Rather than manage one giant configuration file responsible
+  for creating multiple tasks, each task has been broken out into
+  its own file in gulp/tasks. Any files in that directory get
+  automatically required below.
+
+  To add a new task, simply add a new task file in that directory.
+  gulp/tasks/default.js specifies the default set of tasks to run
+  when you run `gulp`.
+*/
+
+var requireDir = require('require-dir');
+
+// Require all tasks in gulp/tasks, including subfolders
+requireDir('./gulp/tasks', { recurse: true });

--- a/examples/pagination/index.html
+++ b/examples/pagination/index.html
@@ -1,0 +1,36 @@
+<!--This is the HTML file that gets served to the browser.  It contains text-->
+<!--that says "Loading..." that will disappear as soon as `bundle.js` has been-->
+<!--downloaded and `lore.summon()` has finished setting up your application.-->
+
+<!--It also contains a DOM element to hang dialogs from so they don't conflict-->
+<!--with any CSS or JavaScript behaviors in the application (styling overrides-->
+<!--or event bubbling cancellation).-->
+
+<html>
+  <head>
+    <title>Lore Example: Pagination</title>
+    <style>
+      .loading-text {
+        text-align: center;
+        line-height: 100vh;
+        font-size: 32px;
+        margin: 0;
+        font-weight: bold;
+        color: rgba(0,0,0,.54);
+      }
+    </style>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div id="root">
+      <h1 class="loading-text">
+        Loading...
+      </h1>
+    </div>
+    <div id="dialog"></div>
+
+    <script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <script src="/dist/bundle.js"></script>
+  </body>
+</html>

--- a/examples/pagination/index.js
+++ b/examples/pagination/index.js
@@ -1,0 +1,16 @@
+/**
+* This file kicks off the build process for the application.  It also attaches
+* the Lore singleton to the window, so you can access it from the command line
+* in case you need to play with it or want to manually kick off actions or check
+* the reducer state (through `lore.actions.xyz`, `lore.reducers.xyz`,
+* `lore.models.xyz`, etc.)
+**/
+
+var lore = require('lore');
+
+// Allows you to access your lore app globally as well as from within
+// the console. Remove this line if you don't want to be able to do that.
+window.lore = lore;
+
+// Summon the app!
+lore.summon();

--- a/examples/pagination/initializers/REAMDE.md
+++ b/examples/pagination/initializers/REAMDE.md
@@ -1,0 +1,18 @@
+# app/initializers
+
+### Purpose
+
+Any files put in the initializers directory will be ran at Lore start-up.
+This is essentially used to boostrap anything needed when your app starts up.
+
+### Example
+
+For example.. let's say for some reason that you want to print 'hello world'
+at startup you would add the following file to /initializers
+
+```
+/* helloWorld.js */
+module.exports = function() {
+  console.log('hello world');
+};
+```

--- a/examples/pagination/package.json
+++ b/examples/pagination/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "pagination",
+  "private": true,
+  "version": "0.0.0",
+  "description": "A Lore application",
+  "main": "server.js",
+  "keywords": [],
+  "scripts": {
+    "start": "node server.js",
+    "test": "NODE_ENV=test mocha --recursive"
+  },
+  "dependencies": {
+    "classnames": "2.1.3",
+    "invariant": "2.1.0",
+    "jquery": "2.1.4",
+    "lodash": "3.10.1",
+    "lore": "~0.7.0",
+    "moment": "2.10.3",
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0",
+    "react-redux": "^4.4.1",
+    "react-router": "^2.0.0",
+    "react-tap-event-plugin": "^1.0.0",
+    "redux": "^3.0.2",
+    "redux-thunk": "^2.0.1",
+    "require-dir": "0.3.0"
+  },
+  "devDependencies": {
+    "babel-cli": "6.4.5",
+    "babel-core": "6.2.1",
+    "babel-loader": "6.2.2",
+    "babel-preset-es2015": "6.5.0",
+    "babel-preset-react": "6.5.0",
+    "css-loader": "0.21.0",
+    "file-loader": "0.8.4",
+    "gulp": "3.9.1",
+    "json-loader": "0.5.4",
+    "less": "2.5.1",
+    "less-loader": "2.2.0",
+    "mocha": "2.3.4",
+    "normalize.css": "3.0.3",
+    "react-hot-loader": "^1.3.0",
+    "redux-devtools": "2.1.5",
+    "style-loader": "0.13.0",
+    "webpack": "1.10.5",
+    "webpack-dev-server": "1.10.1",
+    "yargs": "^4.7.1"
+  }
+}
+

--- a/examples/pagination/routes.js
+++ b/examples/pagination/routes.js
@@ -1,0 +1,15 @@
+var React = require('react');
+var Route = require('react-router').Route;
+
+/**
+ * Routes are used to declare your view hierarchy
+ * See: https://github.com/rackt/react-router/blob/master/docs/API.md
+ */
+var Master = require('./src/components/Master');
+var Layout = require('./src/components/Layout');
+
+module.exports = (
+  <Route component={Master}>
+    <Route path="/" component={Layout} />
+  </Route>
+);

--- a/examples/pagination/server.js
+++ b/examples/pagination/server.js
@@ -1,0 +1,41 @@
+/**
+ * This is the development webpack server.  It is required if you want to
+ * support the awesomeness [that is hot reloading](https://vimeo.com/100010922).
+ *
+ * This is the file that gets executed when you run `npm start`.  By default it
+ * will make your project available on port 3000. In production, this file is
+ * never executed.  Instead, the `index.html` file is served up, and the browser
+ * looks for `/dist/bundle.js` (which webpack will have built when the project
+ * when the project was deployed).
+ **/
+
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+var config = require('./webpack.config');
+var url = require('url');
+var _ = require('lodash');
+
+function getDevServerPort() {
+  var devServerEntry = _.find(config.entry, function(entry) {
+    return entry.indexOf('webpack-dev-server/client?') === 0;
+  });
+  var devServer = devServerEntry.split('?')[1];
+  return url.parse(devServer).port;
+}
+
+var PORT = getDevServerPort();
+
+new WebpackDevServer(webpack(config), {
+  publicPath: config.output.publicPath,
+  hot: true,
+  historyApiFallback: true,
+  stats: {
+    colors: true
+  }
+}).listen(PORT, 'localhost', function (err) {
+  if (err) {
+    console.log(err);
+  }
+
+  console.log('Listening at localhost:' + PORT);
+});

--- a/examples/pagination/src/README.md
+++ b/examples/pagination/src/README.md
@@ -1,0 +1,4 @@
+# app/src
+
+This folder contains all of your core JavaScript code like models, components, project constants, reducers, 
+dialogs, etc.

--- a/examples/pagination/src/actions/README.md
+++ b/examples/pagination/src/actions/README.md
@@ -1,0 +1,47 @@
+# app/src/actions
+
+### Purpose
+
+This folder is where you define any custom actions or override the ones defined by the blueprints.
+
+### Example
+
+If you wanted to wanted override the default behavior for the `todo.fetchAll` action for example, you just need to 
+define a file called `actions/todo/fetchAll.js` and populate it with the following: 
+
+```js
+var ActionTypes = require('../constants/ActionTypes');
+var PayloadStates = require('../constants/PayloadStates');
+var utils = require('lore-actions').utils;
+
+module.exports = function fetchAll(query) {
+  query = query || {};
+
+  return function(dispatch) {
+    var collection = new lore.collections.todo();
+
+    collection.fetch({
+      data: query
+    }).done(function () {
+      dispatch({
+        type: ActionTypes.FETCH_TODOS,
+        payload: utils.payloadCollection(collection, query, PayloadStates.RESOLVED),
+        query: query
+      })
+    }).fail(function (response) {
+      var error = response.responseJSON;
+      dispatch({
+        type: ActionTypes.FETCH_TODOS,
+        payload: utils.payload(collection, PayloadStates.ERROR_FETCHING, error),
+        query: query
+      })
+    });
+
+    return dispatch({
+      type: ActionTypes.FETCH_TODOS,
+      payload: utils.payloadCollection(collection, PayloadStates.FETCHING),
+      query: query
+    })
+  }
+}
+```

--- a/examples/pagination/src/collections/README.md
+++ b/examples/pagination/src/collections/README.md
@@ -1,0 +1,27 @@
+# app/src/collections
+
+### Purpose
+
+This folder is where you can override any framework conventions related to specific collections. If you're application
+consumes a single API, and that API has consistent conventions across all the endpoints, you shouldn't need to create 
+any files in this folder. If your application consumes multiple endpoints, you'll need to create files in here to 
+notify Lore which collections belong to which endpoints.  You'll also need to define files in this folder if the
+API you're consuming has inconsistent structure across the endpoints, and you need to define a custom parse method
+for specific collections (meaning the default parse method in `config/collections.js` isn't applicable to every
+collection.
+
+### Example
+
+```js
+module.exports = {
+
+  properties: {
+
+    // parse: function(attributes) {
+    //   return attributes;
+    // }
+
+  }
+
+};
+```

--- a/examples/pagination/src/collections/repository.js
+++ b/examples/pagination/src/collections/repository.js
@@ -1,0 +1,11 @@
+module.exports = {
+
+  properties: {
+    parse: function(attributes) {
+      this.meta = {
+        totalCount: attributes.total_count
+      };
+      return attributes.items;
+    }
+  }
+};

--- a/examples/pagination/src/components/Header.js
+++ b/examples/pagination/src/components/Header.js
@@ -1,0 +1,20 @@
+var React = require('react');
+var Router = require('react-router');
+
+module.exports = React.createClass({
+  displayName: 'Header',
+
+  render: function () {
+    return (
+      <nav className="navbar navbar-default navbar-static-top">
+        <div className="container">
+          <div className="navbar-header">
+            <Router.Link className="navbar-brand" to={{pathname: '/'}}>
+              Pagination
+            </Router.Link>
+          </div>
+        </div>
+      </nav>
+    );
+  }
+});

--- a/examples/pagination/src/components/Layout.js
+++ b/examples/pagination/src/components/Layout.js
@@ -1,0 +1,31 @@
+/**
+ * This component is intended to reflect the high level structure of your application,
+ * and render any components that are common across all views, such as the header or
+ * top-level navigation. All other components should be rendered by route handlers.
+ **/
+
+var React = require('react');
+var Header = require('./Header');
+var List = require('./List');
+
+module.exports = React.createClass({
+  displayName: 'Layout',
+
+  render: function() {
+    var location = this.props.location;
+
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-offset-3 col-md-6">
+              <List location={location} />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});

--- a/examples/pagination/src/components/List.js
+++ b/examples/pagination/src/components/List.js
@@ -1,0 +1,145 @@
+/**
+ * This component is intended to reflect the high level structure of your application,
+ * and render any components that are common across all views, such as the header or
+ * top-level navigation. All other components should be rendered by route handlers.
+ **/
+
+var React = require('react');
+var Header = require('./Header');
+var Router = require('react-router');
+var PayloadStates = require('../constants/PayloadStates');
+var Pagination = require('./Pagination');
+var Repository = require('./Repository');
+
+var REPOS_PER_PAGE = 10;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      repositories: getState('repository.find', {
+        where: {
+          q: 'stars:>1000',
+          sort: 'stars',
+          per_page: REPOS_PER_PAGE,
+          page: props.location.query.page || '1'
+        }
+      })
+    }
+  },
+  Router.withRouter(React.createClass({
+    displayName: 'List',
+
+    getStyles: function(isLoading) {
+      return {
+        title: {
+          textAlign: 'center'
+        },
+        loading: {
+          textAlign: 'center',
+          marginTop: '64px',
+          fontSize: '32px',
+          fontWeight: 'bold',
+          color: 'rgba(0,0,0,.54)'
+        },
+        repositories: {
+          marginTop: '32px',
+          opacity: isLoading ? '0.3' : '1'
+        },
+        repository: {
+          media: {
+            // border: '1px solid #ddd'
+          },
+          image: {
+            width: '64px',
+            height: '64px'
+          }
+        },
+        pagination: {
+          textAlign: 'center'
+        }
+      }
+    },
+
+    getInitialState: function() {
+      return {
+        previousRepositories: {
+          state: PayloadStates.FETCHING
+        }
+      };
+    },
+
+    onNavigate: function(pageNumber) {
+      this.setState({
+        previousRepositories: this.props.repositories
+      });
+
+      this.props.router.push({
+        pathname: '/',
+        query: { page: pageNumber }
+      });
+    },
+
+    renderRepository: function(repository) {
+      return (
+        <Repository key={repository.id} repository={repository} />
+      );
+    },
+
+    render: function() {
+      var repositories = this.props.repositories;
+      var previousRepositories = this.state.previousRepositories;
+      var isLoading = (repositories.state === PayloadStates.FETCHING);
+      var styles = this.getStyles(isLoading);
+      var currentPage = this.props.location.query.page || '1';
+      var title = 'Most Popular GitHub Repositories';
+
+      if (isLoading && previousRepositories.state === PayloadStates.FETCHING) {
+        return (
+          <div>
+            <h2 style={styles.title}>{title}</h2>
+            <h2 style={styles.loading}>Loading...</h2>
+          </div>
+        );
+      }
+
+      if (isLoading && previousRepositories.state === PayloadStates.RESOLVED) {
+        repositories = previousRepositories;
+      }
+
+      if(repositories.state === PayloadStates.ERROR_FETCHING) {
+        return (
+          <div>
+            <h2 style={styles.title}>{title}</h2>
+            <div>
+              <div>
+                <p>{repositories.error.message}</p>
+              </div>
+              <div>
+                <p>Please see this link for more information:</p>
+                <p>
+                  <a href={repositories.error.documentation_url}>
+                    {repositories.error.documentation_url}
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div>
+          <h2 style={styles.title}>{title}</h2>
+          <ul className="media-list" style={styles.repositories}>
+            {repositories.data.map(this.renderRepository)}
+          </ul>
+          <Pagination
+            repositories={repositories}
+            reposPerPage={REPOS_PER_PAGE}
+            currentPage={currentPage}
+            onNavigate={this.onNavigate} />
+        </div>
+      );
+    }
+
+  }))
+);

--- a/examples/pagination/src/components/Master.js
+++ b/examples/pagination/src/components/Master.js
@@ -1,0 +1,65 @@
+/**
+ * This component serves as the root of your application.  Typically, it should be the only
+ * component subscribed to the store.
+ **/
+
+var React = require('react');
+
+module.exports = lore.connect({subscribe: true}, function(getState, props) {
+    return {};
+  },
+  React.createClass({
+    displayName: 'Master',
+
+    render: function() {
+      return (
+        <div>
+          {React.cloneElement(this.props.children)}
+        </div>
+      );
+    }
+  })
+);
+
+/**
+ * If your application has authentication, this is a good place to fetch the
+ * current user.  Assuming you've created an action that knows how to fetch
+ * the user, and a reducer to store the user, and defined the map between them
+ * in `config/reducerActionMap`, you would do something like this:
+ *
+ * var React = require('react');
+ * var PayloadStates = require('../constants/PayloadStates');
+ *
+ * module.exports = lore.connect({
+ *     subscribe: true
+ *   }, function(getState, props){
+ *     return {
+ *       user: getState('user.current')
+ *     }
+ *   },
+ *   React.createClass({
+ *     displayName: 'Master',
+ *
+ *     propTypes: {
+ *       children: React.PropTypes.any,
+ *       user: React.PropTypes.object.isRequired
+ *     },
+ *
+ *     render: function() {
+ *       var user = this.props.user;
+ *
+ *       // show some kind of loading screen until we know who the user is
+ *       if(user.state === PayloadStates.FETCHING){
+ *         return (
+ *           <h1>Loading...</h1>
+ *         );
+ *       }
+ *
+ *       return (
+ *         <div>{this.props.children}</div>
+ *       );
+ *     }
+ *   })
+ * );
+ * 
+ **/

--- a/examples/pagination/src/components/Pagination.js
+++ b/examples/pagination/src/components/Pagination.js
@@ -1,0 +1,144 @@
+var React = require('react');
+var Router = require('react-router');
+var PaginationLink = require('./PaginationLink');
+
+module.exports = React.createClass({
+  displayName: 'Pagination',
+
+  getStyles: function() {
+    return {
+      pagination: {
+        textAlign: 'center'
+      }
+    }
+  },
+
+  renderPaginationLink: function(pageNumber, currentPage) {
+    if(pageNumber === currentPage) {
+      return (
+        <PaginationLink key={pageNumber} page={pageNumber} isActive={true} />
+      );
+    }
+
+    return (
+      <PaginationLink key={pageNumber} page={pageNumber} isActive={false} onNavigate={this.props.onNavigate}/>
+    );
+  },
+
+  renderPreviousPageLink: function(currentPage) {
+    var previousPage = currentPage - 1;
+
+    if(currentPage === 1) {
+      return (
+        <PaginationLink key="previous" isDisabled={true} text={"&laquo;"} />
+      );
+    }
+
+    return (
+      <PaginationLink key="previous" page={previousPage} text={"&laquo;"} onNavigate={this.props.onNavigate}/>
+    );
+  },
+
+  renderNextPageLink: function(currentPage, totalPages) {
+    var nextPage = currentPage + 1;
+
+    if(currentPage === totalPages) {
+      return (
+        <PaginationLink key="next" isDisabled={true} text={"&raquo;"} />
+      );
+    }
+
+    return (
+      <PaginationLink key="next" page={nextPage} text={"&raquo;"} onNavigate={this.props.onNavigate}/>
+    );
+  },
+
+  renderDividerLink: function(key) {
+    return (
+      <PaginationLink key={key} text={'...'} isDisabled={true} />
+    );
+  },
+
+  renderPageLinks: function(currentPage, totalPages) {
+    var links = [];
+
+    if(currentPage < 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderPaginationLink(4, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === 4) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderPaginationLink(4, currentPage));
+      links.push(this.renderPaginationLink(5, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage < totalPages - 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(currentPage -1, currentPage));
+      links.push(this.renderPaginationLink(currentPage, currentPage));
+      links.push(this.renderPaginationLink(currentPage + 1, currentPage));
+      links.push(this.renderDividerLink('divider-2'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === totalPages - 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 4, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 3, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === totalPages - 2) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 3, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    }
+
+    return links;
+  },
+
+  render: function() {
+    var repositories = this.props.repositories;
+    var reposPerPage = this.props.reposPerPage;
+    var currentPage = Number(this.props.currentPage);
+    var styles = this.getStyles();
+
+    // Create pagination links
+    var totalRepos = repositories.meta.totalCount;
+    totalRepos = totalRepos > 1000 ? 1000 : totalRepos;
+    var totalPages = Math.ceil(totalRepos/reposPerPage);
+
+    var paginationLinks = this.renderPageLinks(currentPage, totalPages);
+
+    return (
+      <nav style={styles.pagination}>
+        <ul className="pagination">
+          {this.renderPreviousPageLink(currentPage)}
+          {paginationLinks}
+          {this.renderNextPageLink(currentPage, totalPages)}
+        </ul>
+      </nav>
+    );
+  }
+
+});

--- a/examples/pagination/src/components/PaginationLink.js
+++ b/examples/pagination/src/components/PaginationLink.js
@@ -1,0 +1,54 @@
+var React = require('react');
+var Router = require('react-router');
+
+module.exports = React.createClass({
+  displayName: 'PaginationLink',
+
+  propTypes: {
+    page: React.PropTypes.number,
+    text: React.PropTypes.string,
+    isActive: React.PropTypes.bool,
+    isDisabled: React.PropTypes.bool
+  },
+
+  onClick: function(e) {
+    e.preventDefault();
+    this.props.onNavigate(this.props.page);
+  },
+
+  render: function() {
+    var page = this.props.page;
+    var text = this.props.text || page;
+    var isDisabled = this.props.isDisabled;
+    var isActive = this.props.isActive;
+
+    if(isDisabled) {
+      return (
+        <li className="disabled">
+          <a>
+            <span dangerouslySetInnerHTML={{__html: text}} />
+          </a>
+        </li>
+      );
+    }
+
+    if(isActive) {
+      return(
+        <li className="active">
+          <a>
+            <span dangerouslySetInnerHTML={{__html: text}} />
+          </a>
+        </li>
+      );
+    }
+
+    return (
+      <li>
+        <Router.Link to={{ pathname: '/', query: { page: page } }} onClick={this.onClick}>
+          <span dangerouslySetInnerHTML={{__html: text}} />
+        </Router.Link>
+      </li>
+    );
+  }
+
+});

--- a/examples/pagination/src/components/README.md
+++ b/examples/pagination/src/components/README.md
@@ -1,0 +1,4 @@
+# app/src/components
+
+This folder contains all of the components for you application.  If you have dialogs, it's recommended that you place
+them in `app/src/dialogs` or `app/src/components/dialogs`.

--- a/examples/pagination/src/components/Repository.js
+++ b/examples/pagination/src/components/Repository.js
@@ -1,0 +1,59 @@
+var React = require('react');
+var Header = require('./Header');
+
+module.exports = React.createClass({
+  displayName: 'Repository',
+
+  getStyles: function(isLoading) {
+    return {
+      repositories: {
+        marginTop: '32px',
+        opacity: isLoading ? '0.3' : '1'
+      },
+      repository: {
+        media: {
+          // border: '1px solid #ddd'
+        },
+        image: {
+          width: '64px',
+          height: '64px'
+        }
+      },
+      pagination: {
+        textAlign: 'center'
+      }
+    }
+  },
+
+  render: function() {
+    var repository = this.props.repository;
+    var description = repository.data.description;
+    var styles = this.getStyles();
+    var tokens = [];
+
+    if (description.length > 135) {
+      description = description.substring(0,135);
+      tokens = description.split(' ');
+      tokens.pop();
+      description = tokens.join(' ') + '...';
+    }
+
+    return (
+      <li key={repository.id} className="media" style={styles.repository.media}>
+        <div className="media-left">
+          <a href={repository.data.html_url}>
+            <img className="media-object" src={repository.data.owner.avatar_url} style={styles.repository.image}/>
+          </a>
+        </div>
+        <div className="media-body">
+          <h4 className="media-heading">
+            <span className="badge pull-right">{repository.data.stargazers_count}</span>
+            {repository.data.name}
+          </h4>
+          {description}
+        </div>
+      </li>
+    );
+  }
+
+});

--- a/examples/pagination/src/components/Spinner.js
+++ b/examples/pagination/src/components/Spinner.js
@@ -1,0 +1,24 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  displayName: 'Spinner',
+
+  render: function () {
+    return (
+      <svg
+        className="spinner"
+        viewBox="0 0 66 66"
+        xmlns="http://www.w3.org/2000/svg" >
+        <circle
+          className="path"
+          fill="none"
+          strokeWidth="6"
+          strokeLinecap="round"
+          cx="33"
+          cy="33"
+          r="30" />
+      </svg>
+    );
+  }
+
+});

--- a/examples/pagination/src/components/simple/List.js
+++ b/examples/pagination/src/components/simple/List.js
@@ -1,0 +1,101 @@
+/**
+ * This component is intended to reflect the high level structure of your application,
+ * and render any components that are common across all views, such as the header or
+ * top-level navigation. All other components should be rendered by route handlers.
+ **/
+
+var React = require('react');
+var Header = require('./Header');
+var Router = require('react-router');
+var PayloadStates = require('../constants/PayloadStates');
+var Pagination = require('./Pagination');
+
+var REPOS_PER_PAGE = 10;
+
+module.exports = lore.connect(function(getState, props) {
+    return {
+      posts: getState('repository.find', {
+        where: {
+          q: 'stars:>1000',
+          sort: 'stars',
+          per_page: REPOS_PER_PAGE,
+          page: props.location.query.page || '1'
+        }
+      })
+    }
+  },
+  React.createClass({
+    displayName: 'List',
+
+    getStyles: function() {
+      return {
+        repositories: {
+          marginTop: '32px'
+        },
+        repository: {
+          media: {
+            // border: '1px solid #ddd'
+          },
+          image: {
+            width: '64px',
+            height: '64px'
+          }
+        },
+        pagination: {
+          textAlign: 'center'
+        }
+      }
+    },
+
+    renderPost: function(post) {
+      var styles = this.getStyles();
+
+      return (
+        <li key={post.id} className="media" style={styles.repository.media}>
+          <div className="media-left">
+            <a href={post.data.html_url}>
+              <img className="media-object" src={post.data.owner.avatar_url} style={styles.repository.image}/>
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">
+              <span className="badge pull-right">{post.data.stargazers_count}</span>
+              {post.data.name}
+            </h4>
+            {post.data.description}
+          </div>
+        </li>
+      );
+    },
+
+    render: function() {
+      var posts = this.props.posts;
+      var previousPosts = this.previousProps.posts;
+      var styles = this.getStyles();
+      var currentPage = this.props.location.query.page || '1';
+
+      if (posts.state === PayloadStates.FETCHING) {
+        return (
+          <div>
+            <h2>Loading...</h2>
+          </div>
+        );
+      }
+
+      return (
+        <div>
+          <h2>Most Popular GitHub Repositories</h2>
+          <h4>With more than 1k stars</h4>
+          <ul className="media-list" style={styles.repositories}>
+            {posts.data.map(this.renderPost)}
+          </ul>
+          <Pagination
+            repositories={posts}
+            reposPerPage={REPOS_PER_PAGE}
+            currentPage={currentPage} />
+        </div>
+      );
+    }
+
+  })
+);

--- a/examples/pagination/src/components/simple/Pagination.js
+++ b/examples/pagination/src/components/simple/Pagination.js
@@ -1,0 +1,184 @@
+/**
+ * This component is intended to reflect the high level structure of your application,
+ * and render any components that are common across all views, such as the header or
+ * top-level navigation. All other components should be rendered by route handlers.
+ **/
+
+var React = require('react');
+var Router = require('react-router');
+
+function link(text, enabled = true) {
+  return {
+    text: text,
+    enabled: enabled
+  }
+}
+
+module.exports = React.createClass({
+  displayName: 'Pagination',
+
+  getStyles: function() {
+    return {
+      pagination: {
+        textAlign: 'center'
+      }
+    }
+  },
+
+  renderPaginationLink: function(pageNumber, currentPage) {
+    if(pageNumber === currentPage) {
+      return (
+        <li key={pageNumber} className="active">
+          <Router.Link to={{ pathname: '/', query: {page: pageNumber} }}>
+            {pageNumber}
+          </Router.Link>
+        </li>
+      )
+    }
+
+    return (
+      <li key={pageNumber}>
+        <Router.Link to={{ pathname: '/', query: {page: pageNumber} }}>
+          {pageNumber}
+        </Router.Link>
+      </li>
+    )
+  },
+
+  renderPreviousPageLink: function(currentPage) {
+    var previousPage = currentPage - 1;
+
+    if(currentPage === 1) {
+      return (
+        <li key="previous" className="disabled">
+          <a>
+            <span>&laquo;</span>
+          </a>
+        </li>
+      );
+    }
+
+    return (
+      <li key="previous">
+        <Router.Link to={{ pathname: '/', query: { page: previousPage } }}>
+          <span>&laquo;</span>
+        </Router.Link>
+      </li>
+    );
+  },
+
+  renderNextPageLink: function(currentPage, totalPages) {
+    var nextPage = currentPage + 1;
+
+    if(currentPage === totalPages) {
+      return (
+        <li key="next" className="disabled">
+          <a>
+            <span>&raquo;</span>
+          </a>
+        </li>
+      );
+    }
+
+    return (
+      <li key="next">
+        <Router.Link to={{ pathname: '/', query: { page: nextPage } }}>
+          <span>&raquo;</span>
+        </Router.Link>
+      </li>
+    );
+  },
+
+  renderDividerLink: function(key) {
+    return (
+      <li key={key}>
+        <a>
+          <span>...</span>
+        </a>
+      </li>
+    );
+  },
+
+  renderPageLinks: function(currentPage, totalPages) {
+    var links = [];
+
+    if(currentPage < 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderPaginationLink(4, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === 4) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderPaginationLink(2, currentPage));
+      links.push(this.renderPaginationLink(3, currentPage));
+      links.push(this.renderPaginationLink(4, currentPage));
+      links.push(this.renderPaginationLink(5, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage < totalPages - 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(currentPage -1, currentPage));
+      links.push(this.renderPaginationLink(currentPage, currentPage));
+      links.push(this.renderPaginationLink(currentPage + 1, currentPage));
+      links.push(this.renderDividerLink('divider-2'));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === totalPages - 3) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 4, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 3, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else if(currentPage === totalPages - 2) {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 3, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    } else {
+      links.push(this.renderPaginationLink(1, currentPage));
+      links.push(this.renderDividerLink('divider-1'));
+      links.push(this.renderPaginationLink(totalPages - 2, currentPage));
+      links.push(this.renderPaginationLink(totalPages - 1, currentPage));
+      links.push(this.renderPaginationLink(totalPages, currentPage));
+    }
+
+    return links;
+  },
+
+  render: function() {
+    var repositories = this.props.repositories;
+    var reposPerPage = this.props.reposPerPage;
+    var currentPage = Number(this.props.currentPage);
+    var styles = this.getStyles();
+
+    // Create pagination links
+    var totalRepos = repositories.meta.totalCount;
+    totalRepos = totalRepos > 1000 ? 1000 : totalRepos;
+    var totalPages = Math.ceil(totalRepos/reposPerPage);
+
+    var paginationLinks = this.renderPageLinks(currentPage, totalPages);
+
+    return (
+      <nav style={styles.pagination}>
+        <ul className="pagination">
+          {this.renderPreviousPageLink(currentPage)}
+          {paginationLinks}
+          {this.renderNextPageLink(currentPage, totalPages)}
+        </ul>
+      </nav>
+    );
+  }
+
+});

--- a/examples/pagination/src/constants/ActionTypes.js
+++ b/examples/pagination/src/constants/ActionTypes.js
@@ -1,0 +1,19 @@
+/**
+ * app/src/constants/ActionTypes.js
+ *
+ * This file is where you should store any custom ActionTypes required for your
+ * application, ActionTypes that don't fit within the standard framework
+ * conventions.  Alternatively, if you have disabled blueprints, you would need
+ * to specify all of the ActionTypes for the application here.
+ *
+ **/
+
+module.exports = {
+
+  // ADD_TODO:    'ADD_TODO',
+  // UPDATE_TODO: 'UPDATE_TODO',
+  // REMOVE_TODO: 'REMOVE_TODO',
+  // FETCH_TODOS: 'FETCH_TODOS',
+  // FETCH_TODO:  'FETCH_TODO'
+
+};

--- a/examples/pagination/src/constants/PayloadStates.js
+++ b/examples/pagination/src/constants/PayloadStates.js
@@ -1,0 +1,52 @@
+/**
+ * app/src/constants/PayloadStates.js
+ *
+ * This file is where you should store any custom PayloadStates required for
+ * your application.  It is populated by default with the PayloadStates that
+ * Lore uses for the action and reducer blueprints.
+ **/
+
+module.exports = {
+  INITIAL_STATE: 'INITIAL_STATE',
+  RESOLVED: 'RESOLVED',
+  NOT_FOUND: 'NOT_FOUND',
+  CREATING: 'CREATING',
+  UPDATING: 'UPDATING',
+  DELETING: 'DELETING',
+  FETCHING: 'FETCHING',
+  ERROR_CREATING: 'ERROR_CREATING',
+  ERROR_UPDATING: 'ERROR_UPDATING',
+  ERROR_DELETING: 'ERROR_DELETING',
+  ERROR_FETCHING: 'ERROR_FETCHING'
+};
+
+/**
+ * PayloadStates are how you can tell what's happening to a resource within your
+ * application.  For example, all data passed around a Lore app has the following
+ * format:
+ *
+ * var todo = {
+ *   id: '1',
+ *   cid: 'c1',
+ *   state: [PayloadState],
+ *   data: {
+ *     title: 'Explain PayloadStates',
+ *     isCompleted: false
+ *   },
+ *   error: {..some error object..}
+ * }
+ *
+ * The `state` field always contains one of the PayloadState properties, like
+ * `FETCHING` or `UPDATING`.  This stucture allows your components to be able
+ * to know and react to transitionary states within your data.  For example, if a
+ * component gets some data that has a `state` of `FETCHING`, it will know the
+ * data is currently being retrieved from the server and it should maybe show a
+ * spinner or some other kind of waiting message.  If the `state` is `RESOLVED`,
+ * the component will know the data is stable (nothing in flight) and if the
+ * `state` is `UPDATING` it would know that the application is currently waiting
+ * on confirmation from the server about a change to the data.  The `ERROR_*`
+ * states exist in case there's an error performing an operation on the server
+ * side and you want to articulate to the user what failed (Create, Update,
+ * Delete, etc.) and perhaps give them an opportunity to modify the request and
+ * try again.
+ **/

--- a/examples/pagination/src/constants/README.md
+++ b/examples/pagination/src/constants/README.md
@@ -1,0 +1,5 @@
+# app/src/constants
+
+This folder contains any constants that are used across your application. Typically that means strings that you need
+to use in mulitple places.  Putting them here, and defining them as a variable, means you can change them in a single
+location and have the change automatically ripple through the application (no find/replace-all behavior).

--- a/examples/pagination/src/models/README.md
+++ b/examples/pagination/src/models/README.md
@@ -1,0 +1,29 @@
+# app/src/models
+
+### Purpose
+
+This folder is where you define the models that your application uses, and is where all the magic/conventions in Lore
+derive from.  For example, if you create a file in here called `todo.js`, Lore will see that and generate the following
+Reducers and Actions and ActionTypes by default (provided you haven't turned off blueprints).
+
+**Reducers:**
+todo.all, todo.by, todo.byCid
+
+**Actions:**
+todo.fetchAll, todo.fetch, todo.create, todo.update, todo.destroy
+
+**ActionTypes:**
+FETCH_TODOS, FETCH_TODO, CREATE_TODO, UPDATE_TODO, DESTROY_TODO
+
+
+### Example
+
+```js
+module.exports = {
+  properties: {
+    // parse: function(attributes) {
+    //   return attributes;
+    // }
+  }
+};
+```

--- a/examples/pagination/src/models/repository.js
+++ b/examples/pagination/src/models/repository.js
@@ -1,0 +1,3 @@
+module.exports = {
+
+};

--- a/examples/pagination/src/reducers/README.md
+++ b/examples/pagination/src/reducers/README.md
@@ -1,0 +1,34 @@
+# app/src/reducers
+
+### Purpose
+
+This folder is where you define any custom reducers or override the ones defined by the blueprints.
+
+### Example
+
+```js
+var _ = require('lodash');
+var ActionTypes = require('../constants/ActionTypes');
+var PayloadStates = require('../constants/PayloadStates');
+
+var initialState = {
+  state: PayloadStates.INITIAL_STATE,
+  data: []
+};
+
+return function customReducer(state, action) {
+  state = state || initialState;
+  var nextState = _.assign({}, state);
+
+  switch (action.type) {
+    case ActionTypes.FOUND_SOMETHING_COOL:
+      // push the cool things into the array of other cool things
+      return _.assign(nextState, {
+         data: nextState.data.concat(action.payload.data)
+       });
+
+    default:
+      return nextState
+  }
+};
+```

--- a/examples/pagination/webpack.config.js
+++ b/examples/pagination/webpack.config.js
@@ -1,0 +1,46 @@
+/**
+ * This file builds and exports the final webpack config using the default
+ * configuration in `/webpack/config.js` plus any environment specific
+ * overrides that should be applied on top of it.
+ *
+ * This file also needs to specify the application root and pass it to the
+ * webpack configs in `/webpack`, so `/webpack/config.js` can define the
+ * `__LORE_ROOT__` constant (which the Lore framework uses to build file paths
+ * to project folders like /models, /actions, /reducers, etc.
+ *
+ * Because webpack bundles the project into a single file under
+ * `/dist/bundle.js`, it needs to know at *build* time what files it needs to
+ * include.  So while dynamic require statements will work in a Node app
+ * (because `require()` is a synchronous operation, that approach won't work
+ * with Webpack. All file paths need to be explicit during build time.  The
+ * alternative was to use relative paths to back out of the `lore` package in
+ * `node_modules` and into the project itself, but that seemed like a worse
+ * and somewhat fragile alternative.
+ **/
+
+var requireDir = require('require-dir');
+var _ = require('lodash');
+var yargs = require('yargs');
+
+var envConfigs = requireDir('./webpack/env');
+
+var settings = {
+  APP_ROOT: __dirname,
+  PORT: yargs.argv.port || 3000
+};
+
+// build the base webpack config
+var config = require('./webpack/config')(settings);
+
+// get the environment specific config
+var env = process.env.NODE_ENV || 'development';
+var envConfig = envConfigs[env];
+
+// if there is a config for this environment, override the base
+// config with whatever is specified there
+if (envConfig) {
+  _.assign(config, envConfig(settings));
+}
+
+// export the final config file
+module.exports = config;

--- a/examples/pagination/webpack/README.md
+++ b/examples/pagination/webpack/README.md
@@ -1,0 +1,5 @@
+# app/webpack
+
+This folder contains everything needed to build the webpack configuration. By default it includes environment
+overrides for development and production, but you can add as many additional overrides as you need (like staging).
+Just create a file in `/env` called `staging.js` and add whatever webpack overrides you need.

--- a/examples/pagination/webpack/config.js
+++ b/examples/pagination/webpack/config.js
@@ -1,0 +1,73 @@
+/**
+ * This file is the default webpack config. You can override it on a per environment basis by specifying
+ * environment specific files in /env.
+ *
+ * The intent with this file is to:
+ *
+ * 1. Have a build process that works out of the box so you don't have to learn Webpack until you want/need to.
+ * 2. Have it include all the common loaders, so you don't have to figure out how to add things like jsx, css and images
+ * into your project.
+ * 3. Alias `react`, so you don't hit any issues with duplicate copies of React due to npm packages that aren't using a
+ * peerDependency for React.
+ * 4. Declare the application root as the **__LORE_ROOT__** variable, so that Lore knows where your project is in the
+ * file system and can require all necessary files at build time.
+ **/
+
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = function(settings) {
+  var APP_ROOT = settings.APP_ROOT;
+
+  return {
+    devtool: 'eval',
+    entry: [
+      './index'
+    ],
+    output: {
+      path: path.join(APP_ROOT, "tmp/dist"),
+      filename: "bundle.js",
+      publicPath: "/dist/"
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        __LORE_ROOT__: JSON.stringify(APP_ROOT)
+      })
+    ],
+    resolve: {
+      extensions: ['', '.js', '.jsx'],
+      alias: {
+        'react': APP_ROOT + '/node_modules/react'
+      }
+    },
+    module: {
+
+      loaders: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: "babel-loader",
+          include: APP_ROOT,
+          query: {
+            presets: ['react', 'es2015']
+          }
+        },{
+          test: /\.js$/,
+          loaders: ['babel-loader'],
+          include: path.join(APP_ROOT, '..', '..', 'src')
+        },{
+          test: /\.css/,
+          loader: 'style-loader!css-loader'
+        },{
+          test: /\.less$/,
+          loader: 'style-loader!css-loader!less-loader'
+        },{
+          test: /\.(png|jpg)$/,
+          loader: 'url-loader?limit=8192'
+        },{
+          test: /\.json/,
+          loader: 'json-loader'
+      }]
+    }
+  }
+};

--- a/examples/pagination/webpack/env/README.md
+++ b/examples/pagination/webpack/env/README.md
@@ -1,0 +1,3 @@
+# app/webpack/env
+
+This folder contains any environment specific overrides for the webpack config.

--- a/examples/pagination/webpack/env/development.js
+++ b/examples/pagination/webpack/env/development.js
@@ -1,0 +1,29 @@
+/**
+ * Development specific settings for webpack
+ *
+ * This file is where you define any webpack config overrides that should be applied in the development environment. The
+ * development environment is defined as `NODE_ENV=development` or the absense of an `NODE_ENV` environment variable.
+ *
+ **/
+
+var webpack = require('webpack');
+
+module.exports = function(settings) {
+  var APP_ROOT = settings.APP_ROOT;
+  var PORT = settings.PORT;
+
+  return {
+    entry: [
+      'webpack-dev-server/client?http://localhost:' + PORT,
+      'webpack/hot/only-dev-server',
+      './index'
+    ],
+    plugins: [
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoErrorsPlugin(),
+      new webpack.DefinePlugin({
+        __LORE_ROOT__: JSON.stringify(APP_ROOT)
+      })
+    ]
+  }
+};

--- a/examples/pagination/webpack/env/production.js
+++ b/examples/pagination/webpack/env/production.js
@@ -1,0 +1,13 @@
+/**
+ * Production specific settings for webpack
+ *
+ * This file is where you define webpack config overrides that should take place when operating under the production 
+ * environment. The production environment is defined as `NODE_ENV=production`.
+ *
+ **/
+
+module.exports = function(settings) {
+  return {
+    // add production specific webpack settings
+  }
+};

--- a/packages/lore-actions/src/utils.js
+++ b/packages/lore-actions/src/utils.js
@@ -58,7 +58,8 @@ function payloadCollection( collection, state, error ) {
     error: error || {},
     data: collection.models.map(function( model ) {
       return payload(model, state, error);
-    })
+    }),
+    meta: collection.meta
   };
 }
 

--- a/packages/lore-actions/test/blueprints/find.spec.js
+++ b/packages/lore-actions/test/blueprints/find.spec.js
@@ -55,6 +55,7 @@ describe('blueprints#find', function() {
       payload: {
         state: PayloadStates.FETCHING,
         data: [],
+        meta: undefined,
         error: {}
       }
     });
@@ -101,6 +102,7 @@ describe('blueprints#find', function() {
                 error: {}
               }
             ],
+            meta: undefined,
             error: {}
           }
         });
@@ -136,6 +138,7 @@ describe('blueprints#find', function() {
           payload: {
             state: PayloadStates.ERROR_FETCHING,
             data: [],
+            meta: undefined,
             error: {
               message: 'You do not have permission to retrieve this resource'
             }

--- a/packages/lore-actions/test/utils.spec.js
+++ b/packages/lore-actions/test/utils.spec.js
@@ -62,6 +62,7 @@ describe('utils', function() {
             field: 'someError'
           }
         }],
+        meta: undefined,
         error: {
           field: 'someError'
         }

--- a/packages/lore/package.json
+++ b/packages/lore/package.json
@@ -46,7 +46,7 @@
     "chai": "3.4.1",
     "json-loader": "0.5.4",
     "mocha": "2.3.4",
-    "nock": "2.6.0",
+    "nock": "^7.0.0",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/packages/lore/test/integration/reducerBlueprints/pagination.spec.js
+++ b/packages/lore/test/integration/reducerBlueprints/pagination.spec.js
@@ -1,0 +1,108 @@
+var expect = require('chai').expect;
+var Lore = require('../../../src/app/index');
+var loaderHelper = require('../../helpers/loaderHelper');
+var nock = require('nock');
+var _ = require('lodash');
+
+var API_ROOT = 'https://api.github.com/search';
+var TEST_DELAY = 100;
+
+describe('lore#reducerBlueprints#pagination', function() {
+  var lore = null;
+
+  beforeEach(function() {
+    lore = new Lore();
+  });
+
+  describe('when models exist', function() {
+
+    beforeEach(function() {
+      loaderHelper.stub({
+        config: {
+          models: {
+            apiRoot: API_ROOT
+          }
+        },
+        models: {
+          repository: {}
+        }
+      });
+
+      nock(API_ROOT)
+        .persist()
+        .get('/repositories')
+        .query({
+          q: 'stars:>1000',
+          sort: 'stars',
+          per_page: 5,
+          page: '1'
+        })
+        .reply(200, [
+          { id: 1, title: 'One' },
+          { id: 2, title: 'Two' },
+          { id: 3, title: 'Three' },
+          { id: 4, title: 'Four' },
+          { id: 5, title: 'Five' }
+        ]);
+
+      nock(API_ROOT)
+        .persist()
+        .get(`/repositories`)
+        .query({
+          q: 'stars:>1000',
+          sort: 'stars',
+          per_page: 5,
+          page: '2'
+        })
+        .reply(200, [
+          { id: 6, title: 'Six' },
+          { id: 7, title: 'Seven' },
+          { id: 8, title: 'Eight' },
+          { id: 9, title: 'Nine' },
+          { id: 10, title: 'Ten' }
+        ]);
+    });
+
+    it("should create store states for .byId, .byCid, and. find", function(done) {
+      lore.build();
+      lore.actions.repository.find({
+        q: 'stars:>1000',
+        sort: 'stars',
+        per_page: 5,
+        page: '1'
+      });
+
+      setTimeout(function() {
+        var state = lore.store.getState();
+        var reducer = state.repository.find;
+
+        expect(_.keys(reducer).length).to.eql(1);
+        var page1 = reducer['{"q":"stars:>1000","sort":"stars","per_page":5,"page":"1"}'];
+        expect(page1.data.length).to.eql(5);
+
+        lore.actions.repository.find({
+          q: 'stars:>1000',
+          sort: 'stars',
+          per_page: 5,
+          page: '2'
+        });
+
+        setTimeout(function() {
+          var state = lore.store.getState();
+          var reducer = state.repository.find;
+
+          expect(_.keys(reducer).length).to.eql(2);
+          var page1 = reducer['{"q":"stars:>1000","sort":"stars","per_page":5,"page":"1"}'];
+          var page2 = reducer['{"q":"stars:>1000","sort":"stars","per_page":5,"page":"2"}'];
+
+          expect(page1.data.length).to.eql(5);
+          expect(page2.data.length).to.eql(5);
+          done();
+        }, TEST_DELAY);
+      }, TEST_DELAY);
+
+    });
+  });
+
+});
+


### PR DESCRIPTION
This PR adds an example demonstrating pagination, and makes some changes to `lore` in service of that goal. This is PR is part 1 of 2 in supporting pagination.

### Example Screenshot
This example pulls data from the GitHub search API and displays a list of the most popular repositories. GitHub limits the search results to the top 1000, which is why there are 100 pages with 10 results per page. Clicking on a new page will cause the current page results to fade (opacity = 0.3) until the new page results come back. All pages are cached in the reducers, so clicking back to a previous page will load immediately.

![lore_example_pagination_shadow](https://cloud.githubusercontent.com/assets/2637399/16700754/86da78c0-4510-11e6-83bf-cd6ae2f0580c.png)

### Changes to Lore
1. Added tests for pagination
2. Cleaned up the `find` reducer blueprint a bit, fixing a bug and making it a bit easier to understand. Eventually, I want to expose some of the settings (like deleting data from list, merging new data into existing lists) as options in `config/reducerBlueprints`.
