### PR TITLE
Provide project support for ESNext syntax & enable lore.connect usage as a decorator

### DIFF
--- a/packages/lore-generate-collection/generator.js
+++ b/packages/lore-generate-collection/generator.js
@@ -20,7 +20,7 @@ module.exports = Generator.extend({
     var result = {};
     var filename = './src/collections/' + camelCase(options.collectionName) + '.js';
 
-    if (options.es6) {
+    if (options.es6 || options.esnext) {
       result[filename] = { copy: './collection.es6.js'};
     } else {
       result[filename] = { copy: './collection.es5.js'};

--- a/packages/lore-generate-component/generator.js
+++ b/packages/lore-generate-component/generator.js
@@ -16,7 +16,9 @@ module.exports = Generator.extend({
 	targets: function(options) {
     var template = './component';
 
-    if (options.es6) {
+    if (options.esnext) {
+      template += '.esnext'
+    } else if (options.es6) {
       template += '.es6'
     } else {
       template += '.es5'

--- a/packages/lore-generate-component/index.js
+++ b/packages/lore-generate-component/index.js
@@ -14,6 +14,10 @@ module.exports = {
         description: 'Name of the component',
         type: 'string'
       },
+      esnext: {
+        alias: 'n',
+        describe: 'Generate an ESNext version of the component'
+      },
       es6: {
         alias: '6',
         describe: 'Generate an ES6 version of the component'

--- a/packages/lore-generate-component/templates/component.es5.connect.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.js
@@ -4,7 +4,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       //models: getState('model.find')
     }
-  },
+  })(
   React.createClass({
     displayName: '<%= componentName %>',
 

--- a/packages/lore-generate-component/templates/component.es5.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es5.connect.router.js
@@ -5,7 +5,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       //models: getState('model.find')
     }
-  },
+  })(
   Router.withRouter(React.createClass({
     displayName: '<%= componentName %>',
 

--- a/packages/lore-generate-component/templates/component.es6.connect.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.js
@@ -27,4 +27,4 @@ export default lore.connect((getState, props) => {
   return {
     //models: getState('model.find')
   };
-}, <%= componentName %>);
+})(<%= componentName %>);

--- a/packages/lore-generate-component/templates/component.es6.connect.router.js
+++ b/packages/lore-generate-component/templates/component.es6.connect.router.js
@@ -29,4 +29,4 @@ export default lore.connect((getState, props) => {
   return {
     //models: getState('model.find')
   };
-}, withRouter(<%= componentName %>));
+})(withRouter(<%= componentName %>));

--- a/packages/lore-generate-component/templates/component.esnext.connect.js
+++ b/packages/lore-generate-component/templates/component.esnext.connect.js
@@ -1,0 +1,31 @@
+import React, { Component, PropTypes } from 'react';
+
+@lore.connect((getState, props) => {
+  return {
+    //models: getState('model.find')
+  };
+})
+class <%= componentName %> extends Component {
+
+  static propTypes = {
+    //models: React.PropTypes.object.isRequired
+  };
+  
+  constructor(props) {
+    super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.esnext.connect.router.js
+++ b/packages/lore-generate-component/templates/component.esnext.connect.router.js
@@ -1,0 +1,34 @@
+import React, { Component, PropTypes } from 'react';
+import { Link, withRouter } from 'react-router';
+
+@withRouter
+@lore.connect((getState, props) => {
+  return {
+    //models: getState('model.find')
+  };
+})
+class <%= componentName %> extends Component {
+
+  static propTypes = {
+    //models: React.PropTypes.object.isRequired,
+    router: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.esnext.js
+++ b/packages/lore-generate-component/templates/component.esnext.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+
+class <%= componentName %> extends Component {
+
+  static propTypes = {};
+
+  constructor(props) {
+    super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+export default <%= componentName %>;

--- a/packages/lore-generate-component/templates/component.esnext.router.js
+++ b/packages/lore-generate-component/templates/component.esnext.router.js
@@ -1,0 +1,28 @@
+import React, { Component, PropTypes } from 'react';
+import { Link, withRouter } from 'react-router';
+
+@withRouter
+class <%= componentName %> extends Component {
+
+  static propTypes = {
+    router: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+
+    // Set your initial state here
+    // this.setState = {};
+
+    // Bind your custom methods so you can access the expected 'this'
+    // this.myCustomMethod = this.myCustomMethod.bind(this);
+  }
+
+  render() {
+    return (
+      <div></div>
+    )
+  }
+}
+
+export default <%= componentName %>;

--- a/packages/lore-generate-github/generator.js
+++ b/packages/lore-generate-github/generator.js
@@ -65,7 +65,7 @@ module.exports = Generator.extend({
   },
 
   targets: function(options) {
-    if (options.es6) {
+    if (options.es6 || options.esnext) {
       return {
         './gulp/tasks/github.js': { copy: 'gulp/tasks/github.es6.js'}
       };

--- a/packages/lore-generate-model/generator.js
+++ b/packages/lore-generate-model/generator.js
@@ -18,12 +18,12 @@ module.exports = Generator.extend({
     var result = {};
     var filename = './src/models/' + camelCase(options.modelName) + '.js';
 
-    if (options.es6) {
+    if (options.es6 || options.esnext) {
       result[filename] = { copy: './model.es6.js'};
     } else {
       result[filename] = { copy: './model.es5.js'};
     }
-    
+
     return result;
   }
 

--- a/packages/lore-generate-new/generator.js
+++ b/packages/lore-generate-new/generator.js
@@ -3,6 +3,7 @@ var fs = require('fs-extra');
 var Generator = require('lore-generate').Generator;
 var es5Targets = require('./targets/es5');
 var es6Targets = require('./targets/es6');
+var esnextTargets = require('./targets/esnext');
 
 module.exports = Generator.extend({
 
@@ -32,7 +33,9 @@ module.exports = Generator.extend({
   },
 
   targets: function(options) {
-    if (options.es6) {
+    if (options.esnext) {
+      return esnextTargets;
+    } else if (options.es6) {
       return es6Targets;
     } else {
       return es5Targets;

--- a/packages/lore-generate-new/index.js
+++ b/packages/lore-generate-new/index.js
@@ -14,6 +14,10 @@ module.exports = {
         description: 'Name of the application',
         type: 'string'
       },
+      esnext: {
+        alias: 'n',
+        describe: 'Generate an ESNext version of the project'
+      },
       es6: {
         alias: '6',
         describe: 'Generate an ES6 version of the project'

--- a/packages/lore-generate-new/targets/esnext.js
+++ b/packages/lore-generate-new/targets/esnext.js
@@ -1,0 +1,96 @@
+var path = require('path');
+
+function common(template) {
+  return path.join('common', template);
+}
+
+function es6(template) {
+  return path.join('es6', template);
+}
+
+function esnext(template) {
+  return path.join('esnext', template);
+}
+
+module.exports = {
+
+  // root
+  './.babelrc': {copy: esnext('.babelrc')},
+  './.editorconfig': {copy: common('editorconfig.template')},
+  './.gitignore': {copy: common('gitignore')},
+  './index.html': {copy: common('index.html')},
+  './index.js': {copy: es6('index.js')},
+  './.lorerc': {copy: esnext('lorerc')},
+  './gulpfile.js': {copy: es6('gulpfile.js')},
+  './package.json': {template: esnext('package.json')},
+  './README.md': {template: common('./README.md')},
+  './routes.js': {copy: es6('routes.js')},
+  './server.js': {copy: es6('server.js')},
+  './webpack.config.js': {copy: es6('webpack.config.js')},
+
+  // webpack
+  './webpack/config.js': {copy: esnext('webpack/config.js')},
+  './webpack/README.md': {copy: common('webpack/README.md')},
+  './webpack/env/development.js': {copy: es6('webpack/env/development.js')},
+  './webpack/env/production.js': {copy: es6('webpack/env/production.js')},
+  './webpack/env/README.md': {copy: common('webpack/env/README.md')},
+
+  // src
+  './src/README.md': {copy: common('src/README.md')},
+
+  // actions
+  './src/actions/README.md': {copy: common('src/actions/README.md')},
+
+  // collections
+  './src/collections/README.md': {copy: common('src/collections/README.md')},
+
+  // components
+  './src/components/README.md': {copy: common('src/components/README.md')},
+  './src/components/Layout.js': {copy: es6('src/components/Layout.js')},
+  './src/components/Master.js': {copy: esnext('src/components/Master.js')},
+
+  // constants
+  './src/constants/README.md': {copy: common('src/constants/README.md')},
+  './src/constants/ActionTypes.js': {copy: es6('src/constants/ActionTypes.js')},
+  './src/constants/PayloadStates.js': {copy: es6('src/constants/PayloadStates.js')},
+
+  // dialogs
+  './src/dialogs/.gitkeep': {copy: common('.gitkeep')},
+
+  // mixins
+  './src/mixins/.gitkeep': {copy: common('.gitkeep')},
+
+  // mixins
+  './src/models/README.md': {copy: common('src/models/README.md')},
+
+  // reducers
+  './src/reducers/README.md': {copy: common('src/reducers/README.md')},
+
+  // config
+  './config/actionBlueprints.js': {copy: es6('config/actionBlueprints.js')},
+  './config/actions.js': {copy: es6('config/actions.js')},
+  './config/collections.js': {copy: es6('config/collections.js')},
+  './config/connect.js': {copy: es6('config/connect.js')},
+  './config/dialog.js': {copy: es6('config/dialog.js')},
+  './config/local.js': {copy: es6('config/local.js')},
+  './config/models.js': {copy: es6('config/models.js')},
+  './config/reducerActionMap.js': {copy: es6('config/reducerActionMap.js')},
+  './config/reducerBlueprints.js': {copy: es6('config/reducerBlueprints.js')},
+  './config/reducers.js': {copy: es6('config/reducers.js')},
+  './config/redux.js': {copy: es6('config/redux.js')},
+  './config/router.js': {copy: es6('config/router.js')},
+  './config/README.md': {copy: common('config/README.md')},
+
+  // config/env
+  './config/env/development.js': {copy: es6('config/env/development.js')},
+  './config/env/production.js': {copy: es6('config/env/production.js')},
+  './config/env/README.md': {copy: common('config/env/README.md')},
+
+  // gulp
+  './gulp/tasks/default.js': {copy: es6('gulp/tasks/default.js')},
+  './gulp/tasks/README.md': {copy: common('gulp/tasks/README.md')},
+
+  // initializers
+  './initializers/REAMDE.md': {copy: common('initializers/README.md')}
+
+};

--- a/packages/lore-generate-new/templates/es5/src/components/Master.js
+++ b/packages/lore-generate-new/templates/es5/src/components/Master.js
@@ -5,9 +5,9 @@
 
 var React = require('react');
 
-module.exports = lore.connect({subscribe: true}, function(getState, props) {
-    return {};
-  },
+module.exports = lore.connect(function(getState, props) {
+  return {};
+}, { subscribe: true })(
   React.createClass({
     displayName: 'Master',
 
@@ -30,13 +30,11 @@ module.exports = lore.connect({subscribe: true}, function(getState, props) {
  * var React = require('react');
  * var PayloadStates = require('../constants/PayloadStates');
  *
- * module.exports = lore.connect({
- *     subscribe: true
- *   }, function(getState, props){
- *     return {
- *       user: getState('user.current')
- *     }
- *   },
+ * module.exports = lore.connect(function(getState, props){
+ *   return {
+ *     user: getState('user.current')
+ *   }
+ * }, {subscribe: true})(
  *   React.createClass({
  *     displayName: 'Master',
  *
@@ -61,5 +59,5 @@ module.exports = lore.connect({subscribe: true}, function(getState, props) {
  *     }
  *   })
  * );
- * 
+ *
  **/

--- a/packages/lore-generate-new/templates/es6/.babelrc
+++ b/packages/lore-generate-new/templates/es6/.babelrc
@@ -1,5 +1,8 @@
 {
-  "presets": ["es2015"],
+  "presets": [
+    "es2015",
+    "react"
+  ],
   "plugins": [
     "add-module-exports"
   ]

--- a/packages/lore-generate-new/templates/es6/src/components/Master.js
+++ b/packages/lore-generate-new/templates/es6/src/components/Master.js
@@ -17,11 +17,9 @@ class Master extends React.Component {
 
 }
 
-export default lore.connect({ subscribe: true }, function(getState, props) {
-    return {};
-  },
-  Master
-);
+export default lore.connect(function(getState, props) {
+  return {};
+}, { subscribe: true })(Master);
 
 /**
  * If your application has authentication, this is a good place to fetch the
@@ -64,7 +62,7 @@ export default lore.connect({ subscribe: true }, function(getState, props) {
  *   },
  *   Master
  * );
- * 
+ *
  **/
 
 

--- a/packages/lore-generate-new/templates/es6/webpack/config.js
+++ b/packages/lore-generate-new/templates/es6/webpack/config.js
@@ -52,7 +52,10 @@ module.exports = function(settings) {
           loader: "babel-loader",
           include: APP_ROOT,
           query: {
-            presets: ['react', 'es2015']
+            presets: [
+              'react',
+              'es2015'
+            ]
           }
         },{
           test: /\.js$/,

--- a/packages/lore-generate-new/templates/esnext/.babelrc
+++ b/packages/lore-generate-new/templates/esnext/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    "es2015",
+    "react"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "transform-decorators-legacy",
+    "transform-class-properties"
+  ]
+}

--- a/packages/lore-generate-new/templates/esnext/lorerc
+++ b/packages/lore-generate-new/templates/esnext/lorerc
@@ -1,0 +1,6 @@
+{
+  "generators": {
+    "language": "esnext"
+  },
+  "hooks": {}
+}

--- a/packages/lore-generate-new/templates/esnext/package.json
+++ b/packages/lore-generate-new/templates/esnext/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "<%= appName %>",
+  "private": true,
+  "version": "0.0.0",
+  "description": "A Lore application",
+  "main": "server.js",
+  "keywords": [],
+  "scripts": {
+    "start": "babel-node server.js",
+    "test": "NODE_ENV=test mocha --recursive"
+  },
+  "dependencies": {
+    "classnames": "2.1.3",
+    "invariant": "2.1.0",
+    "jquery": "2.1.4",
+    "lodash": "3.10.1",
+    "lore": "~0.7.0",
+    "moment": "2.10.3",
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0",
+    "react-redux": "^4.4.1",
+    "react-router": "^2.0.0",
+    "react-tap-event-plugin": "^1.0.0",
+    "redux": "^3.0.2",
+    "redux-thunk": "^2.0.1",
+    "require-dir": "0.3.0"
+  },
+  "devDependencies": {
+    "babel-cli": "6.4.5",
+    "babel-core": "6.2.1",
+    "babel-loader": "6.2.2",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-class-properties": "^6.10.2",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "6.5.0",
+    "babel-preset-react": "6.5.0",
+    "css-loader": "0.21.0",
+    "file-loader": "0.8.4",
+    "gulp": "3.9.1",
+    "json-loader": "0.5.4",
+    "less": "2.5.1",
+    "less-loader": "2.2.0",
+    "mocha": "2.3.4",
+    "normalize.css": "3.0.3",
+    "react-hot-loader": "^1.3.0",
+    "redux-devtools": "2.1.5",
+    "style-loader": "0.13.0",
+    "webpack": "1.10.5",
+    "webpack-dev-server": "1.10.1",
+    "yargs": "^4.7.1"
+  }
+}
+

--- a/packages/lore-generate-new/templates/esnext/src/components/Master.js
+++ b/packages/lore-generate-new/templates/esnext/src/components/Master.js
@@ -1,0 +1,66 @@
+/**
+ * This component serves as the root of your application.  Typically, it should be the only
+ * component subscribed to the store.
+ **/
+
+import React from 'react';
+
+@lore.connect(function(getState, props) {
+  return {};
+}, { subscribe: true })
+class Master extends React.Component {
+
+  render() {
+    return (
+      <div>
+        {React.cloneElement(this.props.children)}
+      </div>
+    );
+  }
+
+}
+
+export default Master;
+
+/**
+ * If your application has authentication, this is a good place to fetch the
+ * current user.  Assuming you've created an action that knows how to fetch
+ * the user, and a reducer to store the user, and defined the map between them
+ * in `config/reducerActionMap`, you would do something like this:
+ *
+ *  import React from 'react';
+ *  import PayloadStates from '../constants/PayloadStates';
+ *
+ *  @lore.connect(function(getState, props){
+ *    return {
+ *      user: getState('user.current')
+ *    }
+ *  }, { subscribe: true })
+ *  class Master extends React.Component {
+ *
+ *    static propTypes = {
+ *      children: React.PropTypes.any,
+ *      user: React.PropTypes.object.isRequired
+ *    };
+ *
+ *    render() {
+ *      const user = this.props.user;
+ *
+ *      // show some kind of loading screen until we know who the user is
+ *      if (user.state === PayloadStates.FETCHING) {
+ *        return (
+ *          <h1>Loading...</h1>
+ *        );
+ *      }
+ *
+ *      return (
+ *        <div>{this.props.children}</div>
+ *      );
+ *    }
+ *  }
+ *
+ *  export default Master;
+ *
+ **/
+
+

--- a/packages/lore-generate-new/templates/esnext/webpack/config.js
+++ b/packages/lore-generate-new/templates/esnext/webpack/config.js
@@ -1,0 +1,84 @@
+/**
+ * This file is the default webpack config. You can override it on a per environment basis by specifying
+ * environment specific files in /env.
+ *
+ * The intent with this file is to:
+ *
+ * 1. Have a build process that works out of the box so you don't have to learn Webpack until you want/need to.
+ * 2. Have it include all the common loaders, so you don't have to figure out how to add things like jsx, css and images
+ * into your project.
+ * 3. Alias `react`, so you don't hit any issues with duplicate copies of React due to npm packages that aren't using a
+ * peerDependency for React.
+ * 4. Declare the application root as the **__LORE_ROOT__** variable, so that Lore knows where your project is in the
+ * file system and can require all necessary files at build time.
+ **/
+
+const webpack = require('webpack');
+const path = require('path');
+
+// NOTE: module.exports is used instead of "export default" because Node doesn't understand
+// import/export yet, and using "export default" will break publishing tasks like "gulp surge".
+
+module.exports = function(settings) {
+  const APP_ROOT = settings.APP_ROOT;
+
+  return {
+    devtool: 'eval',
+    entry: [
+      './index'
+    ],
+    output: {
+      path: path.join(APP_ROOT, "tmp/dist"),
+      filename: "bundle.js",
+      publicPath: "/dist/"
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        __LORE_ROOT__: JSON.stringify(APP_ROOT)
+      })
+    ],
+    resolve: {
+      extensions: ['', '.js', '.jsx'],
+      alias: {
+        'react': APP_ROOT + '/node_modules/react'
+      }
+    },
+    module: {
+
+      loaders: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: "babel-loader",
+          include: APP_ROOT,
+          query: {
+            presets: [
+              'react',
+              'es2015'
+            ],
+            plugins: [
+              'add-module-exports',
+              'transform-decorators-legacy',
+              'transform-class-properties'
+            ]
+          }
+        },{
+          test: /\.js$/,
+          loaders: ['babel-loader'],
+          include: path.join(APP_ROOT, '..', '..', 'src')
+        },{
+          test: /\.css/,
+          loader: 'style-loader!css-loader'
+        },{
+          test: /\.less$/,
+          loader: 'style-loader!css-loader!less-loader'
+        },{
+          test: /\.(png|jpg)$/,
+          loader: 'url-loader?limit=8192'
+        },{
+          test: /\.json/,
+          loader: 'json-loader'
+      }]
+    }
+  }
+};

--- a/packages/lore-generate-reducer/generator.js
+++ b/packages/lore-generate-reducer/generator.js
@@ -18,7 +18,7 @@ module.exports = Generator.extend({
     var result = {};
     var filename = './src/reducers/' + camelCase(options.reducerName) + '.js';
 
-    if (options.es6) {
+    if (options.es6 || options.esnext) {
       result[filename] = { copy: './reducer.es6.js'};
     } else {
       result[filename] = { copy: './reducer.es5.js'};

--- a/packages/lore-generate-surge/generator.js
+++ b/packages/lore-generate-surge/generator.js
@@ -75,7 +75,7 @@ module.exports = Generator.extend({
   },
 
   targets: function(options) {
-    if (options.es6) {
+    if (options.es6 || options.esnext) {
       return {
         './gulp/tasks/surge.js': { copy: 'gulp/tasks/surge.es6.js'}
       };

--- a/packages/lore-generate-tutorial/generator.js
+++ b/packages/lore-generate-tutorial/generator.js
@@ -2,6 +2,7 @@ var path = require('path');
 var Generator = require('lore-generate').Generator;
 var es5Targets = require('./targets/es5');
 var es6Targets = require('./targets/es6');
+var esnextTargets = require('./targets/esnext');
 
 module.exports = Generator.extend({
 
@@ -25,7 +26,9 @@ module.exports = Generator.extend({
   },
 
   targets: function(options) {
-    if (options.es6) {
+    if (options.esnext) {
+      return esnextTargets(options);
+    } else if (options.es6) {
       return es6Targets(options);
     } else {
       return es5Targets(options);

--- a/packages/lore-generate-tutorial/targets/esnext.js
+++ b/packages/lore-generate-tutorial/targets/esnext.js
@@ -1,0 +1,85 @@
+var path = require('path');
+var filesForStep = require('./filesForStep');
+
+function common(template) {
+  return path.join('common', template);
+}
+
+function es6(template) {
+  return path.join('es6', template);
+}
+
+function esnext(template) {
+  return path.join('esnext', template);
+}
+
+module.exports = function(options) {
+  var files = filesForStep(options.step);
+
+  switch(options.step) {
+    case 'step1':
+      return files([
+        'index.html'
+      ], common);
+    case 'step2':
+      return files([
+        'src/components/Header.js',
+        'src/components/Layout.js'
+      ], es6);
+    case 'step3':
+      return files([
+        'src/components/ColorCreator.js',
+        'src/components/Layout.js'
+      ], esnext);
+    case 'step4':
+      return files([
+        'src/components/ColorCreator.js'
+      ], esnext);
+    case 'step5':
+      return files([
+        'src/models/color.js'
+      ], es6);
+    case 'step6':
+      return files([
+        'src/components/ColorCreator.js'
+      ], esnext);
+    case 'step7':
+      return files([
+        'src/components/ColorCreator.js'
+      ], esnext);
+    case 'step8':
+      return files([
+        'src/components/ColorCreator.js'
+      ], esnext);
+    case 'step9':
+      return files([
+        'src/components/Color.js',
+        'src/components/ColorCreator.js'
+      ], esnext);
+    case 'step10':
+      return files([
+        'src/components/Color.js',
+        'src/components/Header.js'
+      ], esnext);
+    case 'step11':
+      return files([
+        'routes.js',
+        'src/components/Guessatron.js',
+        'src/components/Layout.js'
+      ], esnext);
+    case 'step12':
+      return files([
+        'src/components/Guessatron.js'
+      ], esnext);
+    case 'step13':
+      return files([
+        'src/components/Guessatron.js'
+      ], esnext);
+    case 'step14':
+      return files([
+        'src/components/Guessatron.js'
+      ], esnext);
+    default:
+      return {};
+  }
+};

--- a/packages/lore-generate-tutorial/templates/es5/step12/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es5/step12/src/components/Guessatron.js
@@ -6,7 +6,7 @@ module.exports = lore.connect(function(getState, props) {
         id: props.params.colorId
       })
     }
-  },
+  })(
   React.createClass({
     displayName: 'Guessatron',
 

--- a/packages/lore-generate-tutorial/templates/es5/step13/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es5/step13/src/components/Guessatron.js
@@ -7,7 +7,7 @@ module.exports = lore.connect(function(getState, props) {
         id: props.params.colorId
       })
     }
-  },
+  })(
   React.createClass({
     displayName: 'Guessatron',
 

--- a/packages/lore-generate-tutorial/templates/es5/step14/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es5/step14/src/components/Guessatron.js
@@ -29,7 +29,7 @@ module.exports = lore.connect(function(getState, props) {
         id: props.params.colorId
       })
     }
-  },
+  })(
   React.createClass({
     displayName: 'Guessatron',
 

--- a/packages/lore-generate-tutorial/templates/es5/step6/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es5/step6/src/components/ColorCreator.js
@@ -6,7 +6,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       colors: getState('color.find')
     }
-  },
+  })(
   React.createClass({
     displayName: 'ColorCreator',
 

--- a/packages/lore-generate-tutorial/templates/es5/step7/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es5/step7/src/components/ColorCreator.js
@@ -6,7 +6,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       colors: getState('color.find')
     }
-  },
+  })(
   React.createClass({
     displayName: 'ColorCreator',
 

--- a/packages/lore-generate-tutorial/templates/es5/step8/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es5/step8/src/components/ColorCreator.js
@@ -6,7 +6,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       colors: getState('color.find')
     }
-  },
+  })(
   React.createClass({
     displayName: 'ColorCreator',
 

--- a/packages/lore-generate-tutorial/templates/es5/step9/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es5/step9/src/components/ColorCreator.js
@@ -7,7 +7,7 @@ module.exports = lore.connect(function(getState, props) {
     return {
       colors: getState('color.find')
     }
-  },
+  })(
   React.createClass({
     displayName: 'ColorCreator',
 

--- a/packages/lore-generate-tutorial/templates/es6/step12/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es6/step12/src/components/Guessatron.js
@@ -42,11 +42,9 @@ Guessatron.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      color: getState('color.byId', {
-        id: props.params.colorId
-      })
-    }
-  },
-  Guessatron
-);
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})(Guessatron);

--- a/packages/lore-generate-tutorial/templates/es6/step13/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es6/step13/src/components/Guessatron.js
@@ -43,11 +43,9 @@ Guessatron.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      color: getState('color.byId', {
-        id: props.params.colorId
-      })
-    }
-  },
-  Guessatron
-);
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})(Guessatron);

--- a/packages/lore-generate-tutorial/templates/es6/step14/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/es6/step14/src/components/Guessatron.js
@@ -66,11 +66,9 @@ Guessatron.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      color: getState('color.byId', {
-        id: props.params.colorId
-      })
-    }
-  },
-  Guessatron
-);
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})(Guessatron);

--- a/packages/lore-generate-tutorial/templates/es6/step6/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es6/step6/src/components/ColorCreator.js
@@ -81,9 +81,7 @@ ColorCreator.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      colors: getState('color.find')
-    }
-  },
-  ColorCreator
-);
+  return {
+    colors: getState('color.find')
+  }
+})(ColorCreator);

--- a/packages/lore-generate-tutorial/templates/es6/step7/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es6/step7/src/components/ColorCreator.js
@@ -83,9 +83,7 @@ ColorCreator.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      colors: getState('color.find')
-    }
-  },
-  ColorCreator
-);
+  return {
+    colors: getState('color.find')
+  }
+})(ColorCreator);

--- a/packages/lore-generate-tutorial/templates/es6/step8/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es6/step8/src/components/ColorCreator.js
@@ -83,9 +83,7 @@ ColorCreator.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      colors: getState('color.find')
-    }
-  },
-  ColorCreator
-);
+  return {
+    colors: getState('color.find')
+  }
+})(ColorCreator);

--- a/packages/lore-generate-tutorial/templates/es6/step9/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/es6/step9/src/components/ColorCreator.js
@@ -82,9 +82,7 @@ ColorCreator.propTypes = {
 };
 
 export default lore.connect(function(getState, props) {
-    return {
-      colors: getState('color.find')
-    }
-  },
-  ColorCreator
-);
+  return {
+    colors: getState('color.find')
+  }
+})(ColorCreator);

--- a/packages/lore-generate-tutorial/templates/esnext/step10/src/components/Color.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step10/src/components/Color.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+class Color extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  render () {
+    const color = this.props.color;
+
+    return (
+      <Link
+        to={'/colors/' + color.id}
+        className="list-group-item"
+        activeClassName="active">
+        {color.data.name}
+      </Link>
+    );
+  }
+
+}
+
+export default Color;

--- a/packages/lore-generate-tutorial/templates/esnext/step10/src/components/Header.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step10/src/components/Header.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+class Header extends React.Component {
+
+  render() {
+    return (
+      <nav className="navbar navbar-default navbar-static-top">
+        <div className="container">
+          <div className="navbar-header">
+            <Link to={'/'} className="navbar-brand">
+              Guessatron 5000
+            </Link>
+          </div>
+        </div>
+      </nav>
+    );
+  }
+
+}
+
+export default Header;

--- a/packages/lore-generate-tutorial/templates/esnext/step11/routes.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step11/routes.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Route, IndexRoute, Redirect } from 'react-router';
+
+/**
+ * Routes are used to declare your view hierarchy
+ * See: https://github.com/rackt/react-router/blob/master/docs/API.md
+ */
+import Master from './src/components/Master';
+import Layout from './src/components/Layout';
+import Guessatron from './src/components/Guessatron';
+
+export default (
+  <Route component={Master}>
+    <Route path="/" component={Layout}>
+      <Route path="colors/:colorId" component={Guessatron} />
+    </Route>
+  </Route>
+);

--- a/packages/lore-generate-tutorial/templates/esnext/step11/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step11/src/components/Guessatron.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+class Guessatron extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    color: {
+      data: {
+        name: 'DeepSkyBlue'
+      }
+    }
+  };
+
+  getStyles() {
+    return {
+      media: {
+        height: '64px',
+        width: '64px',
+        backgroundColor: '#00BFFF'
+      }
+    }
+  }
+
+  render() {
+    const color = this.props.color;
+    const styles = this.getStyles();
+
+    return (
+      <div>
+        <h2>Guessatron Result</h2>
+        <div className="media">
+          <div className="media-left">
+            <a href="#">
+              <div className="media-object" style={styles.media} />
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">{color.data.name}</h4>
+            <em>Is this your color?</em>
+            <div>I hope it is because it's the only color I know.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Guessatron;

--- a/packages/lore-generate-tutorial/templates/esnext/step11/src/components/Layout.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step11/src/components/Layout.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Header from './Header';
+import ColorCreator from './ColorCreator';
+
+class Layout extends React.Component {
+
+  render() {
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-4">
+              <ColorCreator/>
+            </div>
+            <div className="col-md-offset-1 col-md-7">
+              {React.cloneElement(this.props.children || <span/>)}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Layout;

--- a/packages/lore-generate-tutorial/templates/esnext/step12/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step12/src/components/Guessatron.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+@lore.connect(function(getState, props) {
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})
+class Guessatron extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  getStyles() {
+    return {
+      media: {
+        height: '64px',
+        width: '64px',
+        backgroundColor: '#00BFFF'
+      }
+    }
+  }
+
+  render() {
+    const color = this.props.color;
+    const styles = this.getStyles();
+
+    return (
+      <div>
+        <h2>Guessatron Result</h2>
+        <div className="media">
+          <div className="media-left">
+            <a href="#">
+              <div className="media-object" style={styles.media} />
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">{color.data.name}</h4>
+            <em>Is this your color?</em>
+            <div>I hope it is because it's the only color I know.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Guessatron;

--- a/packages/lore-generate-tutorial/templates/esnext/step13/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step13/src/components/Guessatron.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import randomColor from 'randomcolor';
+
+@lore.connect(function(getState, props) {
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})
+class Guessatron extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  getStyles() {
+    return {
+      media: {
+        height: '64px',
+        width: '64px',
+        backgroundColor: randomColor()
+      }
+    }
+  }
+
+  render() {
+    const color = this.props.color;
+    const styles = this.getStyles();
+
+    return (
+      <div>
+        <h2>Guessatron Result</h2>
+        <div className="media">
+          <div className="media-left">
+            <a href="#">
+              <div className="media-object" style={styles.media} />
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">{color.data.name}</h4>
+            <em>Is this your color?</em>
+            <div>I hope it is because it's the only color I know.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Guessatron;

--- a/packages/lore-generate-tutorial/templates/esnext/step14/src/components/Guessatron.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step14/src/components/Guessatron.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import randomColor from 'randomcolor';
+
+/**
+ * Returns a random integer between min and max
+ */
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/**
+ * Return a random bragging phase so the Guessatron can let
+ * you know how awesome it is.
+ */
+function getBragPhrase() {
+  const bragPhrases = [
+    "Nailed it!",
+    "I'm on fire.",
+    "YOU'RE WELCOME.",
+    "I interpret your silence as awe.",
+    "Impressive, right?"
+  ];
+  return bragPhrases[getRandomInt(0,bragPhrases.length - 1)];
+}
+
+@lore.connect(function(getState, props) {
+  return {
+    color: getState('color.byId', {
+      id: props.params.colorId
+    })
+  }
+})
+class Guessatron extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  getStyles() {
+    return {
+      media: {
+        height: '64px',
+        width: '64px',
+        backgroundColor: randomColor()
+      }
+    }
+  }
+
+  render() {
+    const color = this.props.color;
+    const styles = this.getStyles();
+    const bragPhrase = getBragPhrase();
+
+    return (
+      <div>
+        <h2>Guessatron Result</h2>
+        <div className="media">
+          <div className="media-left">
+            <a href="#">
+              <div className="media-object" style={styles.media} />
+            </a>
+          </div>
+          <div className="media-body">
+            <h4 className="media-heading">{color.data.name}</h4>
+            <em>Is this your color?</em>
+            <div>{bragPhrase}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Guessatron;

--- a/packages/lore-generate-tutorial/templates/esnext/step3/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step3/src/components/ColorCreator.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    colors: {
+      data: [
+        {id: 1, data: {name: 'Red'}},
+        {id: 2, data: {name: 'Green'}},
+        {id: 3, data: {name: 'Blue'}}
+      ]
+    }
+  };
+
+  renderColor(color) {
+    return (
+      <a key={color.id} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?" />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button">
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate-tutorial/templates/esnext/step3/src/components/Layout.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step3/src/components/Layout.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Header from './Header';
+import ColorCreator from './ColorCreator';
+
+class Layout extends React.Component {
+
+  render() {
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <div className="row">
+            <div className="col-md-4">
+              <ColorCreator/>
+            </div>
+            <div className="col-md-offset-1 col-md-7">
+              {/* Guessatron's result will go here */}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Layout;

--- a/packages/lore-generate-tutorial/templates/esnext/step4/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step4/src/components/ColorCreator.js
@@ -1,0 +1,93 @@
+import React from 'react';
+
+const ENTER_KEY = 13;
+
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    colors: {
+      data: [
+        {id: 1, data: {name: 'Red'}},
+        {id: 2, data: {name: 'Green'}},
+        {id: 3, data: {name: 'Blue'}}
+      ]
+    }
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newColor: ''
+    };
+    this.onChangeNewColor = this.onChangeNewColor.bind(this);
+    this.onKeyPressNewColor = this.onKeyPressNewColor.bind(this);
+    this.onCreateColor = this.onCreateColor.bind(this);
+  }
+
+  onChangeNewColor(event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  }
+
+  onKeyPressNewColor(event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  }
+
+  onCreateColor() {
+    const value = this.state.newColor.trim();
+
+    if (value) {
+      console.log('Creating color: ' + value);
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  }
+
+  renderColor(color) {
+    return (
+      <a key={color.id} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyPressNewColor}
+            onChange={this.onChangeNewColor} />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate-tutorial/templates/esnext/step6/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step6/src/components/ColorCreator.js
@@ -1,0 +1,88 @@
+import React from 'react';
+
+const ENTER_KEY = 13;
+
+@lore.connect(function(getState, props) {
+  return {
+    colors: getState('color.find')
+  }
+})
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newColor: ''
+    };
+    this.onChangeNewColor = this.onChangeNewColor.bind(this);
+    this.onKeyPressNewColor = this.onKeyPressNewColor.bind(this);
+    this.onCreateColor = this.onCreateColor.bind(this);
+  }
+
+  onChangeNewColor(event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  }
+
+  onKeyPressNewColor(event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  }
+
+  onCreateColor() {
+    const value = this.state.newColor.trim();
+
+    if (value) {
+      console.log('Creating color: ' + value);
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  }
+
+  renderColor(color) {
+    return (
+      <a key={color.id} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyPressNewColor}
+            onChange={this.onChangeNewColor} />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate-tutorial/templates/esnext/step7/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step7/src/components/ColorCreator.js
@@ -1,0 +1,90 @@
+import React from 'react';
+
+const ENTER_KEY = 13;
+
+@lore.connect(function(getState, props) {
+  return {
+    colors: getState('color.find')
+  }
+})
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newColor: ''
+    };
+    this.onChangeNewColor = this.onChangeNewColor.bind(this);
+    this.onKeyPressNewColor = this.onKeyPressNewColor.bind(this);
+    this.onCreateColor = this.onCreateColor.bind(this);
+  }
+
+  onChangeNewColor(event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  }
+
+  onKeyPressNewColor(event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  }
+
+  onCreateColor() {
+    const value = this.state.newColor.trim();
+
+    if (value) {
+      lore.actions.color.create({
+        name: value
+      });
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  }
+
+  renderColor(color) {
+    return (
+      <a key={color.id} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyPressNewColor}
+            onChange={this.onChangeNewColor} />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate-tutorial/templates/esnext/step8/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step8/src/components/ColorCreator.js
@@ -1,0 +1,90 @@
+import React from 'react';
+
+const ENTER_KEY = 13;
+
+@lore.connect(function(getState, props) {
+  return {
+    colors: getState('color.find')
+  }
+})
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newColor: ''
+    };
+    this.onChangeNewColor = this.onChangeNewColor.bind(this);
+    this.onKeyPressNewColor = this.onKeyPressNewColor.bind(this);
+    this.onCreateColor = this.onCreateColor.bind(this);
+  }
+
+  onChangeNewColor(event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  }
+
+  onKeyPressNewColor(event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  }
+
+  onCreateColor() {
+    const value = this.state.newColor.trim();
+
+    if (value) {
+      lore.actions.color.create({
+        name: value
+      });
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  }
+
+  renderColor(color) {
+    return (
+      <a key={color.id || color.cid} className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyPressNewColor}
+            onChange={this.onChangeNewColor} />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate-tutorial/templates/esnext/step9/src/components/Color.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step9/src/components/Color.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class Color extends React.Component {
+
+  static propTypes = {
+    color: React.PropTypes.object.isRequired
+  };
+
+  render () {
+    const color = this.props.color;
+
+    return (
+      <a className="list-group-item">
+        {color.data.name}
+      </a>
+    );
+  }
+
+}
+
+export default Color;

--- a/packages/lore-generate-tutorial/templates/esnext/step9/src/components/ColorCreator.js
+++ b/packages/lore-generate-tutorial/templates/esnext/step9/src/components/ColorCreator.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import Color from './Color';
+
+const ENTER_KEY = 13;
+
+@lore.connect(function(getState, props) {
+  return {
+    colors: getState('color.find')
+  }
+})
+class ColorCreator extends React.Component {
+
+  static propTypes = {
+    colors: React.PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newColor: ''
+    };
+    this.onChangeNewColor = this.onChangeNewColor.bind(this);
+    this.onKeyPressNewColor = this.onKeyPressNewColor.bind(this);
+    this.onCreateColor = this.onCreateColor.bind(this);
+  }
+
+  onChangeNewColor(event) {
+    this.setState({
+      newColor: event.target.value
+    });
+  }
+
+  onKeyPressNewColor(event) {
+    if (event.charCode !== ENTER_KEY) {
+      return;
+    }
+    this.onCreateColor();
+  }
+
+  onCreateColor() {
+    const value = this.state.newColor.trim();
+
+    if (value) {
+      lore.actions.color.create({
+        name: value
+      });
+
+      this.setState({
+        newColor: ''
+      });
+    }
+  }
+
+  renderColor(color) {
+    return (
+      <Color key={color.id || color.cid} color={color}/>
+    );
+  }
+
+  render() {
+    const colors = this.props.colors;
+
+    return (
+      <div>
+        <h2>Color Requests</h2>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What color should Guessatron display?"
+            value={this.state.newColor}
+            onKeyPress={this.onKeyPressNewColor}
+            onChange={this.onChangeNewColor} />
+          <span className="input-group-btn">
+            <button className="btn btn-default" type="button" onClick={this.onCreateColor}>
+              Create
+            </button>
+          </span>
+        </div>
+        <div className="list-group" style={{paddingTop: '16px'}}>
+          {colors.data.map(this.renderColor)}
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ColorCreator;

--- a/packages/lore-generate/src/generator/index.js
+++ b/packages/lore-generate/src/generator/index.js
@@ -92,8 +92,11 @@ _.extend(Generator.prototype, {
     var projectDirectory = options.projectDirectory;
 
     // Set the language the generator should use (globally set in .lorerc, can be overrideen by CLI arguments)
-    if (this.lorerc.generators.language === 'es6') {
+    var language = this.lorerc.generators.language;
+    if (language === 'es6') {
       options.es6 = true;
+    } else if (language === 'esnext') {
+      options.esnext = true;
     }
 
     // The `targets` property can be an object or a function, so get the value accordingly

--- a/packages/lore/src/hooks/connect/connect.js
+++ b/packages/lore/src/hooks/connect/connect.js
@@ -42,108 +42,91 @@ module.exports = function(lore) {
   // provide getState with a copy of lore so it can access lore.config.actionReducers (the map)
   var getState = _getState(lore);
 
-  return function connect(/* [options], select, DecoratedComponent */) {
-    var options, select, DecoratedComponent, displayName;
+  return function connect(select, options = {}) {
+    return function(DecoratedComponent) {
+      var displayName = 'Connect(' + getDisplayName(DecoratedComponent) + ')';
 
-    if (arguments.length === 2) {
-      options = {subscribe: false};
-      select = arguments[0];
-      DecoratedComponent = arguments[1];
+      return React.createClass({
+        displayName: displayName,
 
-    } else if (arguments.length === 3) {
-      options = _.assign({subscribe: false}, arguments[0]);
-      select = arguments[1];
-      DecoratedComponent = arguments[2];
+        contextTypes: {
+          store: storeShape.isRequired
+        },
 
-    } else {
-      throw new Error('Invalid number of options. Expected 2 or 3, received ' + arguments.length);
+        getInitialState: function () {
+          var initialState = this.selectState(this.props, this.context);
+          this.nextState = initialState;
+          return {};
+        },
+
+        shouldComponentUpdate: function (nextProps, nextState) {
+          var nextState = this.selectState(nextProps, this.context);
+          this.nextState = nextState;
+          return true;
+        },
+
+        componentDidMount: function () {
+          if (!options.subscribe) {
+            return;
+          }
+
+          this.unsubscribe = this.context.store.subscribe(function () {
+            var nextState = this.selectState(this.props, this.context);
+
+            // Why is setTimeout here?
+            //
+            // If setTimeout is removed you will get the warning "Connect('ComponentName') is accessing
+            // isMounted inside its render() function. render() should be a pure function of props and
+            // state."
+            //
+            // This warning happens because components farther down that chain that call getState in
+            // their own connect() wrappers may fire actions, which update the reducer, which calls
+            // all callbacks subscribed to the store, which calls this function, which then throws
+            // a warning because React checks for the existence of some variable that it can't
+            // find and interprets the lack of that variable as someone attempting to call setState()
+            // or isMounted() from within the render function.
+            //
+            // That isn't what we're doing here (what's happening is perfectly valid code flow) but
+            // React interprets it incorrectly and throws a warning. So to remove the fairly very noisy
+            // warning we're simply going to force the code to wait a tick (~4-10ms) before updating
+            // state.
+
+            setTimeout(function () {
+              // Because setTimeout() is an asynchronous call we can not guarantee the component is
+              // still mounted, so we need to check before updating state
+              if (this.isMounted()) {
+                this.setState(nextState)
+              }
+            }.bind(this), 0);
+          }.bind(this));
+        },
+
+        componentWillUnmount: function () {
+          if (this.unsubscribe) {
+            this.unsubscribe();
+          }
+        },
+
+        selectState: function (props, context) {
+          const state = context.store.getState();
+          const slice = select(getState.bind(null, state), props, context);
+
+          invariant(
+            _.isPlainObject(slice),
+            'The return value of `select` prop must be an object. Instead received %s.',
+            slice
+          );
+
+          return slice;
+        },
+
+        render: function () {
+          return React.createElement(
+            DecoratedComponent,
+            _.assign({ref: 'decoratedComponent'}, this.nextState, this.props)
+          );
+        }
+      });
     }
-
-    displayName = 'Connect(' + getDisplayName(DecoratedComponent) + ')';
-
-    var ConnectorDecorator = React.createClass({
-      displayName: displayName,
-
-      contextTypes: {
-        store: storeShape.isRequired
-      },
-
-      getInitialState: function () {
-        var initialState = this.selectState(this.props, this.context);
-        this.nextState = initialState;
-        return {};
-      },
-
-      shouldComponentUpdate: function (nextProps, nextState) {
-        var nextState = this.selectState(nextProps, this.context);
-        this.nextState = nextState;
-        return true;
-      },
-
-      componentDidMount: function () {
-        if (!options.subscribe) {
-          return;
-        }
-
-        this.unsubscribe = this.context.store.subscribe(function() {
-          var nextState = this.selectState(this.props, this.context);
-
-          // Why is setTimeout here?
-          //
-          // If setTimeout is removed you will get the warning "Connect('ComponentName') is accessing
-          // isMounted inside its render() function. render() should be a pure function of props and
-          // state."
-          //
-          // This warning happens because components farther down that chain that call getState in
-          // their own connect() wrappers may fire actions, which update the reducer, which calls
-          // all callbacks subscribed to the store, which calls this function, which then throws
-          // a warning because React checks for the existence of some variable that it can't
-          // find and interprets the lack of that variable as someone attempting to call setState()
-          // or isMounted() from within the render function.
-          //
-          // That isn't what we're doing here (what's happening is perfectly valid code flow) but
-          // React interprets it incorrectly and throws a warning. So to remove the fairly very noisy
-          // warning we're simply going to force the code to wait a tick (~4-10ms) before updating
-          // state.
-
-          setTimeout(function() {
-            // Because setTimeout() is an asynchronous call we can not guarantee the component is
-            // still mounted, so we need to check before updating state
-            if (this.isMounted()) {
-              this.setState(nextState)
-            }
-          }.bind(this), 0);
-        }.bind(this));
-      },
-
-      componentWillUnmount: function () {
-        if (this.unsubscribe) {
-          this.unsubscribe();
-        }
-      },
-
-      selectState: function (props, context) {
-        const state = context.store.getState();
-        const slice = select(getState.bind(null, state), props, context);
-
-        invariant(
-          _.isPlainObject(slice),
-          'The return value of `select` prop must be an object. Instead received %s.',
-          slice
-        );
-
-        return slice;
-      },
-
-      render: function () {
-        return React.createElement(
-          DecoratedComponent,
-          _.assign({ ref: 'decoratedComponent' }, this.nextState, this.props)
-        );
-      }
-    });
-
-    return ConnectorDecorator;
   }
-
 };


### PR DESCRIPTION
This PR resolves #112 and #58 and provides project support for ESNext syntax.

### Refactor lore.connect to be compatible as a decorator
It refactors the `lore.connect` decorator to support ESNext syntax, such as this:

```jsx
@lore.connect(function(getState, props) {
  return {
    posts: getState('post.find')
  }
})
class PostList extends React.Component {

  static propTypes = {
    posts: React.PropTypes.object.isRequired
  };

  // component code...
}
```

It also modifies all relevant generators to provide support for a dedicated "esnext" experience, similar to the way it supports ES6. 

### ESNext Generator Argument for CLI
When running CLI commands, you can explicity pass in `--esnext` to request the file be generated using ESNext syntax.

### ESNext New Project Template
When creating a new project using `lore new my-app --esnext` the project will be creating using ESNext and the `.lorerc` file will record the language preference as `esnext`, which will automatically be picked up by all generators (to prevent having to explicitly pass in `--esnext` when generating files from within the Lore project).