### PR TITLE
[lore] can bypass action invocation when requesting state

### DIFF
--- a/packages/lore/src/hooks/connect/getState.js
+++ b/packages/lore/src/hooks/connect/getState.js
@@ -13,8 +13,11 @@ module.exports = function(lore) {
       return value;
     }
 
-    return function (state, params) {
+    return function (state, params, options) {
       var param, action, model;
+      options = _.assign({
+        shouldCallAction: true
+      }, options);
 
       if (value.action) {
         action = _.get(lore.actions, value.action);
@@ -76,7 +79,7 @@ module.exports = function(lore) {
         }
       }
 
-      if (action && !model || model.state === PayloadStates.INITIAL_STATE) {
+      if (options.shouldCallAction && action && (!model || model.state === PayloadStates.INITIAL_STATE)) {
         model = action(param || params, params.pagination).payload;
       }
 
@@ -121,7 +124,7 @@ module.exports = function(lore) {
     }
   }
 
-  return function (state, stateKey, params) {
+  return function (state, stateKey, params, options) {
     if (!stateMap) {
       configureStateMap();
     }
@@ -133,7 +136,7 @@ module.exports = function(lore) {
     if (!getState) {
       throw new Error('no getState function found for ' + stateKey + '. Did you mean ' + Object.keys(stateMap).join(", ") + '?');
     }
-    return getState(state, params);
+    return getState(state, params, options);
   };
 
 };


### PR DESCRIPTION
The standard behavior for `lore.connect` is to return the requested state or invoke the action responsible for retrieving that state if it doesn't exist.

This PR allows a component to tell `lore.connect` that it does not want any action to be invoked if that data does not exist. You do so by setting `shouldCallAction` to `false` in the options for `getState`. The new signature looks like this: `getState(stateKey, params, options)`.

### Interface
To make this request, pass an `options` parameter in your `getState` call, like this:

```jsx
lore.connect(function(getState, props) {
  return {
    user: getState('user.current', null, {
      shouldCallAction: false
    })
  }
})
```

### Use Case
I'm not entirely sure what the use case here is, but I was experimenting with using Higher Order Components to simplify the authentication experience, similar to the approach used by [redux-auth-wrapper](https://github.com/mjrussell/redux-auth-wrapper).  

I ended up in a situation where I wanted to find out if the current user existed, but didn't want to fetch them, because if they didn't exist I wouldn't have the API Token required to fetch them anyway.  I wanted to use `lore.connect`, so that I didn't have to manually subscribe to the redux store (and could take advantage of the boilerplate it removes) but there was no option to use `lore.connect` _just_ to retrieve state.

So now there is.

The reason I'm unsure of the use case is because the approach I settled on for authentication didn't require this ability, but I'm adding it to the framework in case it pops up again.