### PR TITLE
[lore-models] allow setting custom headers

### DIFF
--- a/packages/lore-models/src/sync.js
+++ b/packages/lore-models/src/sync.js
@@ -25,9 +25,9 @@ module.exports = function sync(method, model, options) {
   var params = {
     method: type,
     responseType: 'json',
-    headers: {
+    headers: _.assign({
       'Content-Type': 'application/json'
-    }
+    }, _.result(model, 'headers'))
   };
 
   // Ensure that we have a URL.


### PR DESCRIPTION
This PR allows users to set custom headers for Models and Collections when making network requests. This ability is critical when using token-based authentication strategies (as opposed to cookies).

### Use Case
The use case driving this PR was the need to set the `Authorization` header on all network requests, like this:

```
Authorization: Bearer xyz
```

### Interface
To specify custom headers, and a `headers` key to the `properties` field of `config/models.js` and `config/collections.js`

```js
// config/models.js
module.exports = {
  
  apiRoot: 'http://localhost:1337',
  
  pluralize: true,
  
  properties: {

    // Headers that should be applied to all network requests
    // You can override this function on a per-model basis
    headers: function() {
      return {
        'Authorization': 'Bearer ' + localStorage.userToken
      };
    },

    parse: function(attributes) {...}

  }
```

```js
// config/collections.js
module.exports = {
  
  properties: {
    
    // Headers that should be applied to all network requests
    // You can override this function on a per-collection basis
    headers: function() {
      return {
        'Authorization': 'Bearer ' + localStorage.userToken
      };
    },

    parse: function(attributes) {...}
}
```

Like other model and collection properties, these can be overridden on a per-model or per-collection basis, so a `Todo` could have different headers than a `Quote`, or you may need to change your headers if your application consumes data from multiple APIs.