### PR TITLE
Create extract command for actions

### DIFF
--- a/packages/lore-cli/bin/lore.js
+++ b/packages/lore-cli/bin/lore.js
@@ -71,6 +71,15 @@ generators.command(commandify(require('lore-generate-tutorial')));
 app.command(generators);
 
 /**
+ * Category: Extractors
+ */
+var extractors = Cli.createCategory('extract', 'Create files that mirror the blueprint behavior');
+
+extractors.command(commandify(require('lore-extract-action')));
+
+app.command(extractors);
+
+/**
  * Start up the CLI!
  */
 Cli.run(app);

--- a/packages/lore-cli/package.json
+++ b/packages/lore-cli/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "lodash": "3.10.1",
+    "lore-extract-action": "~0.10.0",
     "lore-generate-collection": "~0.9.0",
     "lore-generate-component": "~0.9.0",
     "lore-generate-generator": "~0.9.0",

--- a/packages/lore-extract-action/README.md
+++ b/packages/lore-extract-action/README.md
@@ -1,0 +1,3 @@
+# lore-extract-action
+
+This is an extraction command for the [Lore](http://www.lorejs.org) CLI.

--- a/packages/lore-extract-action/generator.js
+++ b/packages/lore-extract-action/generator.js
@@ -1,0 +1,88 @@
+var path = require('path');
+var camelCase = require('camel-case');
+var Generator = require('lore-generate').Generator;
+
+
+function getFilename(model, blueprint) {
+  return './src/actions/' + model + '/' + blueprint + '.js';
+}
+
+function getBlueprintPath(blueprint, options) {
+  if (options.es6 || options.esnext) {
+    return './es6/' + blueprint + '.js';
+  } else {
+    return './es5/' + blueprint + '.js';
+  }
+}
+
+function getSingleBlueprint(model, blueprint, options, result) {
+  result = result || {};
+  result[getFilename(model, blueprint)] = { template: getBlueprintPath(blueprint, options) };
+  return result;
+}
+
+function getAllBlueprints(model, options) {
+  var result = {};
+  getSingleBlueprint(model, 'create', options, result);
+  getSingleBlueprint(model, 'destroy', options, result);
+  getSingleBlueprint(model, 'find', options, result);
+  getSingleBlueprint(model, 'get', options, result);
+  getSingleBlueprint(model, 'update', options, result);
+  return result;
+}
+
+module.exports = Generator.extend({
+
+  moduleRoot: path.resolve(__dirname),
+
+  templatesDirectory: path.resolve(__dirname, './templates'),
+
+  before: function(options) {
+    var validBlueprints = ['create', 'destroy', 'find', 'get', 'update'];
+
+    var tokens = options.filename.split('/');
+    if (tokens.length > 2) {
+      throw new Error('Invalid format; filename must look like `model` or `model/blueprint`, e.g. `lore extract action post/create`');
+    }
+
+    // set the modelName so the templates can write it into the file
+    options.modelName = camelCase(tokens[0]);
+
+    if (tokens.length > 1) {
+      options.blueprintName = camelCase(tokens[1]);
+
+      if (validBlueprints.indexOf(options.blueprintName) < 0) {
+        throw new Error('Invalid blueprint "' + options.blueprintName + '"; must match one of ' + validBlueprints.join(', '));
+      }
+    }
+
+    if (tokens.length > 1) {
+      this.logger.info('Extracting `' + options.blueprintName + '` action for the `' + options.modelName + '` model...');
+    } else {
+      this.logger.info('Extracting all actions for the `' + options.modelName + '` model...');
+    }
+  },
+
+  after: function(options, targets) {
+    // console.log(options);
+    // console.log(targets);
+    // var filename = options.filename;
+    // var dest = targets[0].destination.relativePath;
+    // this.logger.info('Created a new file `' + filename + '` at `' + dest + '`');
+    targets.forEach(function(target) {
+      this.logger.info('Extracted action to `' + target.destination.relativePath + '`');
+    }.bind(this));
+  },
+
+  targets: function(options) {
+    var modelName = options.modelName;
+    var blueprintName = options.blueprintName;
+
+    if (blueprintName) {
+      return getSingleBlueprint(modelName, blueprintName, options);
+    } else {
+      return getAllBlueprints(modelName, options);
+    }
+  }
+
+});

--- a/packages/lore-extract-action/index.js
+++ b/packages/lore-extract-action/index.js
@@ -2,16 +2,16 @@ var Generator = require('./generator');
 
 module.exports = {
 
-  command: "example",
+  command: "action",
 
-  describe: "Generate an example file in src/examples",
+  describe: "Creates an action that mirrors the behavior of the corresponding blueprint in Lore",
 
   options: {
     params: '<filename>',
 
     options: {
       filename: {
-        description: 'Name of the file',
+        description: 'Name of the file(s) to extract, e.g. `post` or `post/create`',
         type: 'string'
       }
     },

--- a/packages/lore-extract-action/package.json
+++ b/packages/lore-extract-action/package.json
@@ -1,17 +1,19 @@
 {
-  "name": "<%= generatorName %>",
-  "version": "0.1.0",
+  "name": "lore-extract-action",
+  "version": "0.10.0",
   "license": "MIT",
   "main": "index.js",
-  "description": "A generator for the Lore CLI",
+  "description": "Creates an action matching the implicit pattern used by Lore",
   "keywords": [
     "lore",
-    "generator"
+    "extract",
+    "action"
   ],
   "scripts": {
     "test": "NODE_ENV=test mocha --recursive"
   },
   "dependencies": {
+    "camel-case": "^3.0.0",
     "lore-generate": "~0.9.0",
     "bluebird": "3.1.1",
     "lodash": "3.10.1"

--- a/packages/lore-extract-action/templates/es5/create.js
+++ b/packages/lore-extract-action/templates/es5/create.js
@@ -1,0 +1,32 @@
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+var payload = require('lore-utils').payload;
+
+/*
+ * Blueprint for Create method
+ */
+module.exports = function create(params) {
+  return function(dispatch) {
+    var Model = lore.models.<%= modelName %>;
+    var model = new Model(params);
+
+    model.save().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: payload(model, PayloadStates.RESOLVED)
+      });
+    }).catch(function(response) {
+      var error = response.data;
+
+      dispatch({
+        type: ActionTypes.remove('<%= modelName %>'),
+        payload: payload(model, PayloadStates.ERROR_CREATING, error)
+      });
+    });
+
+    return dispatch({
+      type: ActionTypes.add('<%= modelName %>'),
+      payload: payload(model, PayloadStates.CREATING)
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es5/destroy.js
+++ b/packages/lore-extract-action/templates/es5/destroy.js
@@ -1,0 +1,49 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+
+/*
+ * Blueprint for Destroy method
+ */
+module.exports = function destroy(model) {
+  return function(dispatch) {
+    var Model = lore.models.<%= modelName %>;
+    var proxyModel = new Model(model.data);
+
+    proxyModel.destroy().then(function() {
+      dispatch({
+        type: ActionTypes.remove('<%= modelName %>'),
+        payload: _.merge(model, {
+          state: PayloadStates.RESOLVED
+        })
+      });
+    }).catch(function(response) {
+      var error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.ERROR_DELETING,
+            error: error
+          })
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.update('<%= modelName %>'),
+      payload: _.merge(model, {
+        state: PayloadStates.DELETING
+      })
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es5/find.js
+++ b/packages/lore-extract-action/templates/es5/find.js
@@ -1,0 +1,46 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+var payloadCollection = require('lore-utils').payloadCollection;
+
+/*
+ * Blueprint for Find method
+ */
+
+module.exports = function find(query = {}, pagination) {
+  return function(dispatch) {
+    var Collection = lore.models.<%= modelName %>;
+    var collection = new Collection();
+
+    var queryParameters = _.extend({}, query, pagination);
+
+    var combinedQuery = {
+      where: query,
+      pagination: pagination
+    };
+
+    collection.fetch({
+      data: queryParameters
+    }).then(function() {
+      dispatch({
+        type: ActionTypes.fetchPlural('<%= modelName %>'),
+        payload: payloadCollection(collection, PayloadStates.RESOLVED, null, combinedQuery),
+        query: combinedQuery
+      });
+    }).catch(function(response) {
+      var error = response.data;
+
+      dispatch({
+        type: ActionTypes.fetchPlural('<%= modelName %>'),
+        payload: payloadCollection(collection, PayloadStates.ERROR_FETCHING, error, combinedQuery),
+        query: combinedQuery
+      });
+    });
+
+    return dispatch({
+      type: ActionTypes.fetchPlural('<%= modelName %>'),
+      payload: payloadCollection(collection, PayloadStates.FETCHING, null, combinedQuery),
+      query: combinedQuery
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es5/get.js
+++ b/packages/lore-extract-action/templates/es5/get.js
@@ -1,0 +1,45 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+var payload = require('lore-utils').payload;
+
+/*
+ * Blueprint for Get method
+ */
+module.exports = function get(modelId) {
+  return function(dispatch) {
+    var Model = lore.models.<%= modelName %>;
+    var model = new Model({
+      id: modelId
+    });
+
+    model.fetch().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: payload(model, PayloadStates.RESOLVED)
+      });
+    }).catch(function(response) {
+      var error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(payload(model), {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: payload(model, PayloadStates.ERROR_FETCHING, error)
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.add('<%= modelName %>'),
+      payload: payload(model, PayloadStates.FETCHING)
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es5/update.js
+++ b/packages/lore-extract-action/templates/es5/update.js
@@ -1,0 +1,53 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+
+/*
+ * Blueprint for Update method
+ */
+module.exports = function update(model, params) {
+  return function(dispatch) {
+    var Model = lore.models.<%= modelName %>;
+    var proxyModel = new Model(model.data);
+    proxyModel.set(params);
+
+    proxyModel.save().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: _.merge(model, {
+          data: proxyModel.toJSON(),
+          state: PayloadStates.RESOLVED
+        })
+      });
+    }).catch(function(response) {
+      var error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            data: proxyModel.toJSON(),
+            state: PayloadStates.ERROR_UPDATING,
+            error: error
+          })
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.update('<%= modelName %>'),
+      payload: _.merge(model, {
+        data: proxyModel.toJSON(),
+        state: PayloadStates.UPDATING
+      })
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es6/create.js
+++ b/packages/lore-extract-action/templates/es6/create.js
@@ -1,0 +1,30 @@
+import { ActionTypes, PayloadStates, payload } from 'lore-utils';
+
+/*
+ * Blueprint for Create method
+ */
+module.exports = function create(params) {
+  return function(dispatch) {
+    const Model = lore.models.<%= modelName %>;
+    const model = new Model(params);
+
+    model.save().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: payload(model, PayloadStates.RESOLVED)
+      });
+    }).catch(function(response) {
+      const error = response.data;
+
+      dispatch({
+        type: ActionTypes.remove('<%= modelName %>'),
+        payload: payload(model, PayloadStates.ERROR_CREATING, error)
+      });
+    });
+
+    return dispatch({
+      type: ActionTypes.add('<%= modelName %>'),
+      payload: payload(model, PayloadStates.CREATING)
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es6/destroy.js
+++ b/packages/lore-extract-action/templates/es6/destroy.js
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates } from 'lore-utils';
+
+/*
+ * Blueprint for Destroy method
+ */
+module.exports = function destroy(model) {
+  return function(dispatch) {
+    const Model = lore.models.<%= modelName %>;
+    const proxyModel = new Model(model.data);
+
+    proxyModel.destroy().then(function() {
+      dispatch({
+        type: ActionTypes.remove('<%= modelName %>'),
+        payload: _.merge(model, {
+          state: PayloadStates.RESOLVED
+        })
+      });
+    }).catch(function(response) {
+      const error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.ERROR_DELETING,
+            error: error
+          })
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.update('<%= modelName %>'),
+      payload: _.merge(model, {
+        state: PayloadStates.DELETING
+      })
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es6/find.js
+++ b/packages/lore-extract-action/templates/es6/find.js
@@ -1,0 +1,44 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates, payloadCollection } from 'lore-utils';
+
+/*
+ * Blueprint for Find method
+ */
+
+module.exports = function find(query = {}, pagination) {
+  return function(dispatch) {
+    const Collection = lore.models.<%= modelName %>;
+    const collection = new Collection();
+
+    const queryParameters = _.extend({}, query, pagination);
+
+    const combinedQuery = {
+      where: query,
+      pagination: pagination
+    };
+
+    collection.fetch({
+      data: queryParameters
+    }).then(function() {
+      dispatch({
+        type: ActionTypes.fetchPlural('<%= modelName %>'),
+        payload: payloadCollection(collection, PayloadStates.RESOLVED, null, combinedQuery),
+        query: combinedQuery
+      });
+    }).catch(function(response) {
+      const error = response.data;
+
+      dispatch({
+        type: ActionTypes.fetchPlural('<%= modelName %>'),
+        payload: payloadCollection(collection, PayloadStates.ERROR_FETCHING, error, combinedQuery),
+        query: combinedQuery
+      });
+    });
+
+    return dispatch({
+      type: ActionTypes.fetchPlural('<%= modelName %>'),
+      payload: payloadCollection(collection, PayloadStates.FETCHING, null, combinedQuery),
+      query: combinedQuery
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es6/get.js
+++ b/packages/lore-extract-action/templates/es6/get.js
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates, payload } from 'lore-utils';
+
+/*
+ * Blueprint for Get method
+ */
+module.exports = function get(modelId) {
+  return function(dispatch) {
+    const Model = lore.models.<%= modelName %>;
+    const model = new Model({
+      id: modelId
+    });
+
+    model.fetch().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: payload(model, PayloadStates.RESOLVED)
+      });
+    }).catch(function(response) {
+      const error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(payload(model), {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: payload(model, PayloadStates.ERROR_FETCHING, error)
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.add('<%= modelName %>'),
+      payload: payload(model, PayloadStates.FETCHING)
+    });
+  };
+};

--- a/packages/lore-extract-action/templates/es6/update.js
+++ b/packages/lore-extract-action/templates/es6/update.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates } from 'lore-utils';
+
+/*
+ * Blueprint for Update method
+ */
+module.exports = function update(model, params) {
+  return function(dispatch) {
+    const Model = lore.models.<%= modelName %>;
+    const proxyModel = new Model(model.data);
+    proxyModel.set(params);
+
+    proxyModel.save().then(function() {
+      dispatch({
+        type: ActionTypes.update('<%= modelName %>'),
+        payload: _.merge(model, {
+          data: proxyModel.toJSON(),
+          state: PayloadStates.RESOLVED
+        })
+      });
+    }).catch(function(response) {
+      const error = response.data;
+
+      if (response.status === 404) {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            state: PayloadStates.NOT_FOUND,
+            error: error
+          })
+        });
+      } else {
+        dispatch({
+          type: ActionTypes.update('<%= modelName %>'),
+          payload: _.merge(model, {
+            data: proxyModel.toJSON(),
+            state: PayloadStates.ERROR_UPDATING,
+            error: error
+          })
+        });
+      }
+    });
+
+    return dispatch({
+      type: ActionTypes.update('<%= modelName %>'),
+      payload: _.merge(model, {
+        data: proxyModel.toJSON(),
+        state: PayloadStates.UPDATING
+      })
+    });
+  };
+};

--- a/packages/lore-extract-action/test/test.spec.js
+++ b/packages/lore-extract-action/test/test.spec.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('an empty spec', function() {
+  it('passes', function() {
+    expect(true).to.eq(true);
+  });
+});

--- a/packages/lore-generate-generator/templates/generator.js
+++ b/packages/lore-generate-generator/templates/generator.js
@@ -1,6 +1,7 @@
 var path = require('path');
+var Generator = require('lore-generate').Generator;
 
-module.exports = {
+module.exports = Generator.extend({
 
   /**
    * The absolute path to the root of this generator
@@ -51,4 +52,4 @@ module.exports = {
     return files;
   }
 
-};
+});


### PR DESCRIPTION
This PR adds a CLI command that can extract the implicit action(s) in Lore and convert them into explicit project files.

## Use Cases
There are a few use cases for creating this command, though all are variants on faster development and improved transparency:

1. *Taking Control* - The default actions are intended to encompass most use cases for convention-centric REST endpoints, but exceptions run wild in the wild. This command provides an easy way to externalize one of the actions in Lore, so you can quickly begin to override it and tailor that action to work with your exception.

2. *Exploration* - Lore isn't magic, but it might feel that way when you can't see/don't understand what it's doing under the covers. This provides as easy way to find out. If you want to see what happens when you invoke `lore.actions.post.find()` just run `lore extract action post/find` and take a look at it. Then delete the file if you want, and the framework will fallback to using the internal version of the action.

3. *Quick Generation* - while the primary use case for the `extract` command is pulling out implicit behavior in Lore, it can also be used to generate files for as a starting point for actions that have nothing to do with existing models. Running `lore extract action comment/create` will create a file at `src/actions/comment/create.js` regardless of whether that model exists. So you could also use it to generate files as a starting point for new actions you want to create if you know the format will closely match one of the blueprints.

## Usage
To extract an action run the command `lore extract action model/action`, replacing `model` with the name of your Model and `action` with the name of the action you want to extract. For example, if you wanted to extract the `create` action for the `post` model you would run:

`lore extract action post/create`

This will create a file that looks like the following, exactly mirroring what the blueprint inside lore looks like when customized for the requested model:

```js
var ActionTypes = require('lore-utils').ActionTypes;
var PayloadStates = require('lore-utils').PayloadStates;
var payload = require('lore-utils').payload;

/*
 * Blueprint for Create method
 */
module.exports = function create(params) {
  return function(dispatch) {
    var Model = lore.models.post;
    var model = new Model(params);

    model.save().then(function() {
      dispatch({
        type: ActionTypes.update('post'),
        payload: payload(model, PayloadStates.RESOLVED)
      });
    }).catch(function(response) {
      var error = response.data;

      dispatch({
        type: ActionTypes.remove('post'),
        payload: payload(model, PayloadStates.ERROR_CREATING, error)
      });
    });

    return dispatch({
      type: ActionTypes.add('post'),
      payload: payload(model, PayloadStates.CREATING)
    });
  };
};
```

There are five blueprints you can extract for a single model:

```
lore extract action post/create
lore extract action post/destroy
lore extract action post/find
lore extract action post/get
lore extract action post/update
```

If you want to extract ALL blueprints for a model, you can do so (as a shorthand) by ONLY providing the model name, like `lore extract action post`. This command would be identical to running command(s) above for each action independently.