### PR TITLE
Create extract command for reducers

### DIFF
--- a/packages/lore-cli/bin/lore.js
+++ b/packages/lore-cli/bin/lore.js
@@ -76,6 +76,7 @@ app.command(generators);
 var extractors = Cli.createCategory('extract', 'Create files that mirror the blueprint behavior');
 
 extractors.command(commandify(require('lore-extract-action')));
+extractors.command(commandify(require('lore-extract-reducer')));
 
 app.command(extractors);
 

--- a/packages/lore-cli/package.json
+++ b/packages/lore-cli/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "lodash": "3.10.1",
     "lore-extract-action": "~0.10.0",
+    "lore-extract-reducer": "~0.10.0",
     "lore-generate-collection": "~0.9.0",
     "lore-generate-component": "~0.9.0",
     "lore-generate-generator": "~0.9.0",

--- a/packages/lore-extract-action/templates/es6/create.js
+++ b/packages/lore-extract-action/templates/es6/create.js
@@ -3,7 +3,7 @@ import { ActionTypes, PayloadStates, payload } from 'lore-utils';
 /*
  * Blueprint for Create method
  */
-module.exports = function create(params) {
+export default function create(params) {
   return function(dispatch) {
     const Model = lore.models.<%= modelName %>;
     const model = new Model(params);

--- a/packages/lore-extract-action/templates/es6/destroy.js
+++ b/packages/lore-extract-action/templates/es6/destroy.js
@@ -4,7 +4,7 @@ import { ActionTypes, PayloadStates } from 'lore-utils';
 /*
  * Blueprint for Destroy method
  */
-module.exports = function destroy(model) {
+export default function destroy(model) {
   return function(dispatch) {
     const Model = lore.models.<%= modelName %>;
     const proxyModel = new Model(model.data);

--- a/packages/lore-extract-action/templates/es6/find.js
+++ b/packages/lore-extract-action/templates/es6/find.js
@@ -5,7 +5,7 @@ import { ActionTypes, PayloadStates, payloadCollection } from 'lore-utils';
  * Blueprint for Find method
  */
 
-module.exports = function find(query = {}, pagination) {
+export default function find(query = {}, pagination) {
   return function(dispatch) {
     const Collection = lore.models.<%= modelName %>;
     const collection = new Collection();

--- a/packages/lore-extract-action/templates/es6/get.js
+++ b/packages/lore-extract-action/templates/es6/get.js
@@ -4,7 +4,7 @@ import { ActionTypes, PayloadStates, payload } from 'lore-utils';
 /*
  * Blueprint for Get method
  */
-module.exports = function get(modelId) {
+export default function get(modelId) {
   return function(dispatch) {
     const Model = lore.models.<%= modelName %>;
     const model = new Model({

--- a/packages/lore-extract-action/templates/es6/update.js
+++ b/packages/lore-extract-action/templates/es6/update.js
@@ -4,7 +4,7 @@ import { ActionTypes, PayloadStates } from 'lore-utils';
 /*
  * Blueprint for Update method
  */
-module.exports = function update(model, params) {
+export default function update(model, params) {
   return function(dispatch) {
     const Model = lore.models.<%= modelName %>;
     const proxyModel = new Model(model.data);

--- a/packages/lore-extract-reducer/README.md
+++ b/packages/lore-extract-reducer/README.md
@@ -1,0 +1,3 @@
+# lore-extract-reducer
+
+This is an extraction command for the [Lore](http://www.lorejs.org) CLI.

--- a/packages/lore-extract-reducer/generator.js
+++ b/packages/lore-extract-reducer/generator.js
@@ -1,0 +1,82 @@
+var path = require('path');
+var camelCase = require('camel-case');
+var Generator = require('lore-generate').Generator;
+
+
+function getFilename(model, blueprint) {
+  return './src/reducers/' + model + '/' + blueprint + '.js';
+}
+
+function getBlueprintPath(blueprint, options) {
+  if (options.es6 || options.esnext) {
+    return './es6/' + blueprint + '.js';
+  } else {
+    return './es5/' + blueprint + '.js';
+  }
+}
+
+function getSingleBlueprint(model, blueprint, options, result) {
+  result = result || {};
+  result[getFilename(model, blueprint)] = { template: getBlueprintPath(blueprint, options) };
+  return result;
+}
+
+function getAllBlueprints(model, options) {
+  var result = {};
+  getSingleBlueprint(model, 'byId', options, result);
+  getSingleBlueprint(model, 'byCid', options, result);
+  getSingleBlueprint(model, 'find', options, result);
+  getSingleBlueprint(model, 'index', options, result);
+  return result;
+}
+
+module.exports = Generator.extend({
+
+  moduleRoot: path.resolve(__dirname),
+
+  templatesDirectory: path.resolve(__dirname, './templates'),
+
+  before: function(options) {
+    var validBlueprints = ['byId', 'byCid', 'find', 'index'];
+
+    var tokens = options.filename.split('/');
+    if (tokens.length > 2) {
+      throw new Error('Invalid format; filename must look like `model` or `model/blueprint`, e.g. `lore extract reducer post/byId`');
+    }
+
+    // set the modelName so the templates can write it into the file
+    options.modelName = camelCase(tokens[0]);
+
+    if (tokens.length > 1) {
+      options.blueprintName = camelCase(tokens[1]);
+
+      if (validBlueprints.indexOf(options.blueprintName) < 0) {
+        throw new Error('Invalid blueprint "' + options.blueprintName + '"; must match one of ' + validBlueprints.join(', '));
+      }
+    }
+
+    if (tokens.length > 1) {
+      this.logger.info('Extracting `' + options.blueprintName + '` reducer for the `' + options.modelName + '` model...');
+    } else {
+      this.logger.info('Extracting all reducers for the `' + options.modelName + '` model...');
+    }
+  },
+
+  after: function(options, targets) {
+    targets.forEach(function(target) {
+      this.logger.info('Extracted reducer to `' + target.destination.relativePath + '`');
+    }.bind(this));
+  },
+
+  targets: function(options) {
+    var modelName = options.modelName;
+    var blueprintName = options.blueprintName;
+
+    if (blueprintName) {
+      return getSingleBlueprint(modelName, blueprintName, options);
+    } else {
+      return getAllBlueprints(modelName, options);
+    }
+  }
+
+});

--- a/packages/lore-extract-reducer/index.js
+++ b/packages/lore-extract-reducer/index.js
@@ -1,0 +1,25 @@
+var Generator = require('./generator');
+
+module.exports = {
+
+  command: "reducer",
+
+  describe: "Creates a reducer that mirrors the behavior of the corresponding blueprint in Lore",
+
+  options: {
+    params: '<filename>',
+
+    options: {
+      filename: {
+        description: 'Name of the file(s) to extract, e.g. `post` or `post/byId`',
+        type: 'string'
+      }
+    },
+
+    handler: function(argv) {
+      var generator = new Generator(argv);
+      generator.generate(argv);
+    }
+  }
+
+};

--- a/packages/lore-extract-reducer/package.json
+++ b/packages/lore-extract-reducer/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "lore-extract-reducer",
+  "version": "0.10.0",
+  "license": "MIT",
+  "main": "index.js",
+  "description": "Creates a reducer matching the implicit pattern used by Lore",
+  "keywords": [
+    "lore",
+    "extract",
+    "reducer"
+  ],
+  "scripts": {
+    "test": "NODE_ENV=test mocha --recursive"
+  },
+  "dependencies": {
+    "camel-case": "^3.0.0",
+    "lore-generate": "~0.9.0",
+    "bluebird": "3.1.1",
+    "lodash": "3.10.1"
+  },
+  "devDependencies": {
+    "chai": "3.4.1",
+    "mocha": "2.3.4"
+  }
+}

--- a/packages/lore-extract-reducer/templates/es5/byCid.js
+++ b/packages/lore-extract-reducer/templates/es5/byCid.js
@@ -1,0 +1,81 @@
+var ActionTypes = require('lore-utils').ActionTypes;
+var _ = require('lodash');
+
+/*
+ * byCid Reducer Blueprint
+ */
+
+// IMPORTANT!! This is a modified version of _.findKey that doesn't compare types.
+// This is needed because when the API server uses Numbers as primary keys, the
+// initial GET request based on an ID in the url is created as a string in the
+// primary key ({id: '123'}). But when the response comes back from the server, the
+// id is corrected in the data to be a number ({id: 123}).  Without this modified
+// function, you can end up polluting the reducer store with duplicate data because it
+// will see an id of '123' and an id of 123 as two different objects. This function
+// will merge them together, and overwrite the initially incorrect '123' id with the
+// proper 123 id.
+function findKey(state, object) { // 1 or '1'
+  var keys = _.keys(state); // [1,2,'3']
+
+  return _.find(keys, function(key) {
+    return state[key].id == object.id;
+  });
+}
+
+function addOrUpdateByCid(nextState, payload) {
+  var cid = payload && payload.cid;
+  var cidWithDuplicatedId = null;
+
+  if (cid) {
+    if (payload.id) {
+      cidWithDuplicatedId = findKey(nextState, { id: payload.id });
+
+      // if we find a cid with a matching id, update that model with
+      // the latest data, but keep the original cid
+      if (cidWithDuplicatedId) {
+        nextState[cidWithDuplicatedId] = _.assign({}, payload, {
+          cid: cidWithDuplicatedId
+        });
+      } else {
+        nextState[cid] = payload;
+      }
+    } else {
+      nextState[cid] = payload;
+    }
+  }
+
+  return nextState;
+}
+
+function removeByCid(nextState, payload) {
+  var cid = payload && payload.cid;
+  if (cid) {
+    delete nextState[cid];
+  }
+  return nextState;
+}
+
+module.exports = function byCid(state, action) {
+  state = state || {};
+  var nextState = _.assign({}, state);
+
+  switch (action.type) {
+    case ActionTypes.add('<%= modelName %>'):
+      return addOrUpdateByCid(nextState, action.payload);
+
+    case ActionTypes.update('<%= modelName %>'):
+      return addOrUpdateByCid(nextState, action.payload);
+
+    case ActionTypes.remove('<%= modelName %>'):
+      return removeByCid(nextState, action.payload);
+
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      action.payload.data.forEach(function(datum) {
+        addOrUpdateByCid(nextState, datum);
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es5/byId.js
+++ b/packages/lore-extract-reducer/templates/es5/byId.js
@@ -1,0 +1,56 @@
+var ActionTypes = require('lore-utils').ActionTypes;
+var _ = require('lodash');
+
+/*
+ * byId Reducer Blueprint
+ */
+
+function addOrUpdateById(nextState, payload) {
+  var id = payload && payload.id;
+  var existingModel = null;
+
+  if (id) {
+    existingModel = nextState[id];
+    if (existingModel) {
+      nextState[id] = _.assign({}, payload, {
+        cid: existingModel.cid
+      });
+    } else {
+      nextState[id] = payload;
+    }
+  }
+  return nextState;
+}
+
+function removeById(nextState, payload) {
+  var id = payload && payload.id;
+  if (id) {
+    delete nextState[id];
+  }
+  return nextState;
+}
+
+module.exports = function byId(state, action) {
+  state = state || {};
+  var nextState = _.assign({}, state);
+
+  switch (action.type) {
+    case ActionTypes.add('<%= modelName %>'):
+      return addOrUpdateById(nextState, action.payload);
+
+    case ActionTypes.update('<%= modelName %>'):
+      return addOrUpdateById(nextState, action.payload);
+
+    case ActionTypes.remove('<%= modelName %>'):
+      return removeById(nextState, action.payload);
+
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      action.payload.data.forEach(function(datum) {
+        addOrUpdateById(nextState, datum);
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es5/find.js
+++ b/packages/lore-extract-reducer/templates/es5/find.js
@@ -1,0 +1,125 @@
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+var _ = require('lodash');
+
+/*
+ * find Reducer Blueprint
+ */
+
+function mergeDataAndIntersectWithDictionaryKeys(oldData, newData, dictionary) {
+  var ids = _.map(oldData, 'id');
+  var newIds = _.map(newData, 'id');
+  var combinedIds = _.union(ids, newIds);
+  var dictionaryKeys = _.keys(dictionary);
+
+  // If any ids are Numbers, convert them to Strings so we can compare equality
+  // with the dictionary keys
+  var combinedIdsAsStrings = combinedIds.map(function(id) {
+    return id.toString();
+  });
+
+  var idsInDictionary = _.intersection(combinedIdsAsStrings, dictionaryKeys);
+  return idsInDictionary.map(function(id) {
+    return dictionary[id];
+  });
+}
+
+function mergeMissingDataIntoDictionary(data, query, byCid) {
+  var where = query.where;
+  var pagination = query.pagination;
+
+  // Do NOT add data to paginated data sets. This function only exists
+  // to facilitate use cases where the user needs to display ALL results
+  // or results for simple queries (like authorId=xyz)
+  if (pagination && Object.keys(pagination).length > 0) {
+    return;
+  }
+
+  _.keys(byCid).forEach(function(cid) {
+    var datum = byCid[cid];
+    var existingDatum = _.find(data, { cid: cid });
+
+    // if the datum is not in the data set
+    if (!existingDatum) {
+      // if this is the empty query add it (it stores everything)
+      if (Object.keys(where).length === 0) {
+        data.push(datum);
+
+      // else if the datum matches the 'where' query, add it
+      } else if (_.find([datum.data], where)) {
+        data.push(datum);
+      }
+    }
+  })
+}
+
+var SETTINGS = {
+  REMOVE_DESTROYED_DATA: true,
+  ADD_NEW_DATA_TO_QUERIES: true
+};
+
+var initialState = {};
+var EMPTY_QUERY_KEY = JSON.stringify({});
+
+module.exports = function find(state, action, options) {
+  state = state || initialState;
+  var nextState = _.assign({}, state);
+  var byId = options.nextState.byId;
+  var byCid = options.nextState.byCid;
+
+  // Remove any data that no longer exists in byId
+  // This usually means it was deleted
+  if (SETTINGS.REMOVE_DESTROYED_DATA) {
+    nextState = _.mapValues(nextState, function(collection, key) {
+      var ids = collection.data.map(function(data){
+        // id will not always exist for the empty query case: {}
+        return data.id ? data.id.toString() : data.id;
+      });
+
+      // get the list of ids that still exist
+      var idsThatExist = _.keys(byId);
+
+      // get the list of ids that should remain in the collection
+      var validIds = _.intersection(ids, idsThatExist);
+
+      // convert the array of ids in the collection back to real objects
+      collection.data = validIds.map(function(id) {
+        return byId[id];
+      });
+
+      return collection;
+    });
+  }
+
+  // This adds new data to queries it should be in...
+  // Unsure whether this is good or bad...what are the limits?
+  if (SETTINGS.ADD_NEW_DATA_TO_QUERIES) {
+    nextState = _.mapValues(nextState, function(collection, key) {
+      var query = JSON.parse(key);
+
+      mergeMissingDataIntoDictionary(collection.data, query, byCid);
+
+      // sort the data by cid, so it has some kind of default ordering
+      _.sortBy(collection.data, 'cid');
+
+      return collection;
+    });
+  }
+
+  switch (action.type) {
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      var query = JSON.stringify(action.query);
+      nextState[query] = nextState[query] || {};
+      nextState[query] = _.assign({}, action.payload, {
+        data: mergeDataAndIntersectWithDictionaryKeys(
+          nextState[query].data,
+          action.payload.data,
+          byId
+        )
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es5/index.js
+++ b/packages/lore-extract-reducer/templates/es5/index.js
@@ -1,0 +1,36 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var byId = require('./byId');
+var byCid = require('./byCid');
+var find = require('./find');
+
+var initialState = {
+  byId: undefined,
+  byCid: undefined,
+  find: undefined
+};
+
+module.exports = function (state, action) {
+  state = state || initialState;
+
+  // If we receive an action to reset the store (such as when logging out)
+  // reset the state to the initial state
+  if (action.type === ActionTypes.RESET_STORE) {
+    state = initialState;
+  }
+
+  var _byId = byId(state.byId, action);
+  var _byCid = byCid(state.byCid, action);
+  var _find = find(state.find, action, {
+    nextState: {
+      byCid: _byCid,
+      byId: _byId
+    }
+  });
+
+  return {
+    byId: _byId,
+    byCid: _byCid,
+    find: _find
+  };
+};

--- a/packages/lore-extract-reducer/templates/es6/byCid.js
+++ b/packages/lore-extract-reducer/templates/es6/byCid.js
@@ -1,0 +1,81 @@
+import { ActionTypes } from 'lore-utils';
+import _ from 'lodash';
+
+/*
+ * byCid Reducer Blueprint
+ */
+
+// IMPORTANT!! This is a modified version of _.findKey that doesn't compare types.
+// This is needed because when the API server uses Numbers as primary keys, the
+// initial GET request based on an ID in the url is created as a string in the
+// primary key ({id: '123'}). But when the response comes back from the server, the
+// id is corrected in the data to be a number ({id: 123}).  Without this modified
+// function, you can end up polluting the reducer store with duplicate data because it
+// will see an id of '123' and an id of 123 as two different objects. This function
+// will merge them together, and overwrite the initially incorrect '123' id with the
+// proper 123 id.
+function findKey(state, object) { // 1 or '1'
+  const keys = _.keys(state); // [1,2,'3']
+
+  return _.find(keys, function(key) {
+    return state[key].id == object.id;
+  });
+}
+
+function addOrUpdateByCid(nextState, payload) {
+  const cid = payload && payload.cid;
+  let cidWithDuplicatedId = null;
+
+  if (cid) {
+    if (payload.id) {
+      cidWithDuplicatedId = findKey(nextState, { id: payload.id });
+
+      // if we find a cid with a matching id, update that model with
+      // the latest data, but keep the original cid
+      if (cidWithDuplicatedId) {
+        nextState[cidWithDuplicatedId] = _.assign({}, payload, {
+          cid: cidWithDuplicatedId
+        });
+      } else {
+        nextState[cid] = payload;
+      }
+    } else {
+      nextState[cid] = payload;
+    }
+  }
+
+  return nextState;
+}
+
+function removeByCid(nextState, payload) {
+  const cid = payload && payload.cid;
+  if (cid) {
+    delete nextState[cid];
+  }
+  return nextState;
+}
+
+export default function byCid(state, action) {
+  state = state || {};
+  const nextState = _.assign({}, state);
+
+  switch (action.type) {
+    case ActionTypes.add('<%= modelName %>'):
+      return addOrUpdateByCid(nextState, action.payload);
+
+    case ActionTypes.update('<%= modelName %>'):
+      return addOrUpdateByCid(nextState, action.payload);
+
+    case ActionTypes.remove('<%= modelName %>'):
+      return removeByCid(nextState, action.payload);
+
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      action.payload.data.forEach(function(datum) {
+        addOrUpdateByCid(nextState, datum);
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es6/byId.js
+++ b/packages/lore-extract-reducer/templates/es6/byId.js
@@ -1,0 +1,56 @@
+import { ActionTypes } from 'lore-utils';
+import _ from 'lodash';
+
+/*
+ * byId Reducer Blueprint
+ */
+
+function addOrUpdateById(nextState, payload) {
+  const id = payload && payload.id;
+  let existingModel = null;
+
+  if (id) {
+    existingModel = nextState[id];
+    if (existingModel) {
+      nextState[id] = _.assign({}, payload, {
+        cid: existingModel.cid
+      });
+    } else {
+      nextState[id] = payload;
+    }
+  }
+  return nextState;
+}
+
+function removeById(nextState, payload) {
+  const id = payload && payload.id;
+  if (id) {
+    delete nextState[id];
+  }
+  return nextState;
+}
+
+export default function byId(state, action) {
+  state = state || {};
+  let nextState = _.assign({}, state);
+
+  switch (action.type) {
+    case ActionTypes.add('<%= modelName %>'):
+      return addOrUpdateById(nextState, action.payload);
+
+    case ActionTypes.update('<%= modelName %>'):
+      return addOrUpdateById(nextState, action.payload);
+
+    case ActionTypes.remove('<%= modelName %>'):
+      return removeById(nextState, action.payload);
+
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      action.payload.data.forEach(function(datum) {
+        addOrUpdateById(nextState, datum);
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es6/find.js
+++ b/packages/lore-extract-reducer/templates/es6/find.js
@@ -1,0 +1,124 @@
+import { ActionTypes } from 'lore-utils';
+import _ from 'lodash';
+
+/*
+ * find Reducer Blueprint
+ */
+
+function mergeDataAndIntersectWithDictionaryKeys(oldData, newData, dictionary) {
+  const ids = _.map(oldData, 'id');
+  const newIds = _.map(newData, 'id');
+  const combinedIds = _.union(ids, newIds);
+  const dictionaryKeys = _.keys(dictionary);
+
+  // If any ids are Numbers, convert them to Strings so we can compare equality
+  // with the dictionary keys
+  const combinedIdsAsStrings = combinedIds.map(function(id) {
+    return id.toString();
+  });
+
+  const idsInDictionary = _.intersection(combinedIdsAsStrings, dictionaryKeys);
+  return idsInDictionary.map(function(id) {
+    return dictionary[id];
+  });
+}
+
+function mergeMissingDataIntoDictionary(data, query, byCid) {
+  const where = query.where;
+  const pagination = query.pagination;
+
+  // Do NOT add data to paginated data sets. This function only exists
+  // to facilitate use cases where the user needs to display ALL results
+  // or results for simple queries (like authorId=xyz)
+  if (pagination && Object.keys(pagination).length > 0) {
+    return;
+  }
+
+  _.keys(byCid).forEach(function(cid) {
+    const datum = byCid[cid];
+    const existingDatum = _.find(data, { cid: cid });
+
+    // if the datum is not in the data set
+    if (!existingDatum) {
+      // if this is the empty query add it (it stores everything)
+      if (Object.keys(where).length === 0) {
+        data.push(datum);
+
+      // else if the datum matches the 'where' query, add it
+      } else if (_.find([datum.data], where)) {
+        data.push(datum);
+      }
+    }
+  })
+}
+
+const SETTINGS = {
+  REMOVE_DESTROYED_DATA: true,
+  ADD_NEW_DATA_TO_QUERIES: true
+};
+
+const initialState = {};
+
+export default function find(state, action, options) {
+  state = state || initialState;
+
+  let nextState = _.assign({}, state);
+  const byId = options.nextState.byId;
+  const byCid = options.nextState.byCid;
+
+  // Remove any data that no longer exists in byId
+  // This usually means it was deleted
+  if (SETTINGS.REMOVE_DESTROYED_DATA) {
+    nextState = _.mapValues(nextState, function(collection, key) {
+      const ids = collection.data.map(function(data){
+        // id will not always exist for the empty query case: {}
+        return data.id ? data.id.toString() : data.id;
+      });
+
+      // get the list of ids that still exist
+      const idsThatExist = _.keys(byId);
+
+      // get the list of ids that should remain in the collection
+      const validIds = _.intersection(ids, idsThatExist);
+
+      // convert the array of ids in the collection back to real objects
+      collection.data = validIds.map(function(id) {
+        return byId[id];
+      });
+
+      return collection;
+    });
+  }
+
+  // This adds new data to queries it should be in...
+  // Unsure whether this is good or bad...what are the limits?
+  if (SETTINGS.ADD_NEW_DATA_TO_QUERIES) {
+    nextState = _.mapValues(nextState, function(collection, key) {
+      const query = JSON.parse(key);
+
+      mergeMissingDataIntoDictionary(collection.data, query, byCid);
+
+      // sort the data by cid, so it has some kind of default ordering
+      _.sortBy(collection.data, 'cid');
+
+      return collection;
+    });
+  }
+
+  switch (action.type) {
+    case ActionTypes.fetchPlural('<%= modelName %>'):
+      const query = JSON.stringify(action.query);
+      nextState[query] = nextState[query] || {};
+      nextState[query] = _.assign({}, action.payload, {
+        data: mergeDataAndIntersectWithDictionaryKeys(
+          nextState[query].data,
+          action.payload.data,
+          byId
+        )
+      });
+      return nextState;
+
+    default:
+      return nextState
+  }
+};

--- a/packages/lore-extract-reducer/templates/es6/index.js
+++ b/packages/lore-extract-reducer/templates/es6/index.js
@@ -1,0 +1,35 @@
+import { ActionTypes } from 'lore-utils';
+import byId from './byId';
+import byCid from './byCid';
+import find from './find';
+
+var initialState = {
+  byId: undefined,
+  byCid: undefined,
+  find: undefined
+};
+
+export default function (state, action) {
+  let nextState = state || initialState;
+
+  // If we receive an action to reset the store (such as when logging out)
+  // reset the state to the initial state
+  if (action.type === ActionTypes.RESET_STORE) {
+    nextState = initialState;
+  }
+
+  const _byId = byId(nextState.byId, action);
+  const _byCid = byCid(nextState.byCid, action);
+  const _find = find(nextState.find, action, {
+    nextState: {
+      byCid: _byCid,
+      byId: _byId
+    }
+  });
+
+  return {
+    byId: _byId,
+    byCid: _byCid,
+    find: _find
+  };
+}

--- a/packages/lore-extract-reducer/test/test.spec.js
+++ b/packages/lore-extract-reducer/test/test.spec.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('an empty spec', function() {
+  it('passes', function() {
+    expect(true).to.eq(true);
+  });
+});

--- a/packages/lore-hook-reducers/src/reducer.js
+++ b/packages/lore-hook-reducers/src/reducer.js
@@ -19,7 +19,7 @@ module.exports = function compositeReducer(reducers, dependencies) {
     state = state || initialState;
     var nextState = {};
 
-    // If we recieve an action to reset the store (such as when logging out)
+    // If we receive an action to reset the store (such as when logging out)
     // reset the state to the initial state
     if (action.type === ActionTypes.RESET_STORE) {
       state = initialState;
@@ -27,12 +27,12 @@ module.exports = function compositeReducer(reducers, dependencies) {
 
     loadOrder.forEach(function(reducerName) {
       // Equivalent to calling:
-      // var _find = byId(state.find, action, {
+      // var _find = find(state.find, action, {
       //   nextState: {
-      //     byCid: _byCid
+      //     byCid: _byCid,
       //     byId: _byId
       //   }
-      // }
+      // })
       nextState[reducerName] = reducers[reducerName](
         state[reducerName],
         action,


### PR DESCRIPTION
This PR adds a CLI command that can extract the implicit reducer(s) in Lore and convert them into explicit project files.

## Use Cases
There are a few use cases for creating this command, though all are variants on faster development and improved transparency:

1. *Taking Control* - The default reducers are intended to encompass most use cases for convention-centric REST endpoints, but exceptions run wild in the wild. This command provides an easy way to externalize one of the reducers in Lore, so you can quickly begin to override it and tailor that reducer to work with your exception.

2. *Exploration* - Lore isn't magic, but it might feel that way when you can't see/don't understand what it's doing under the covers. This provides as easy way to find out. If you want to see how Lore keep tracks of all the pagination and filter data, just run `lore extract reducer post/find` and take a look at it. Then delete the file if you want, and the framework will fallback to using the internal version of the reducer.

## Usage
To extract a reducer run the command `lore extract reducer model/reducer`, replacing `model` with the name of your Model and `reducer` with the name of the reducer you want to extract. For example, if you wanted to extract the `find` reducer for the `post` model you would run:

`lore extract reducer post/create`

The `find` reducer is a bit complex, so I won't post it here, but you can run the command (or view the file in this PR) if you want to take a look at it.

There are four blueprints you can extract for a single model:

```
lore extract reducer post/byId
lore extract reducer post/byCid
lore extract reducer post/find
lore extract reducer post/index
```

If you want to extract ALL blueprints for a model, you can do so (as a shorthand) by ONLY providing the model name, like `lore extract reducer post`. This command would be identical to running command(s) above for each reducer independently.