### PR TITLE
Make CLI extensible

### DIFF
--- a/packages/lore-cli/package.json
+++ b/packages/lore-cli/package.json
@@ -32,7 +32,8 @@
     "lore-generate-reducer": "~0.9.0",
     "lore-generate-surge": "~0.9.0",
     "lore-generate-tutorial": "~0.9.0",
-    "nested-yargs": "^1.0.7"
+    "nested-yargs": "^1.0.7",
+    "rc": "^1.1.6"
   },
   "devDependencies": {
     "bluebird": "3.1.1",


### PR DESCRIPTION
This PR makes the CLI extensible from within a project, allowing you to add new commands and overwrite existing commands.

Up until now, the `.lorerc` file has had no purpose beyond recording the language preference for the project (ES5, ES6 or ESNext). This PR makes it much more useful.

## Use Cases
The Lore CLI is intended to be a complimentary tool for the project. While it started off as a convenience for generating basic project files, the `extract` commands are extremely useful, and there are other commands in the planning stage for rewriting the `ActionTypes` file to include the implicit ActionTypes, as well as commands to generate the boilerplate for different authentication strategies/approaches. Commands that are more "opt-in" by nature, and maybe don't belong in the CLI core.

Additionally, having to modify the CLI in order to test out new commands is laborious and high friction. The CLI should be easy to work with and easy to extend, and this PR allows you to develop and test new commands within your own project. With this PR the CLI is essentially the DEFAULT commands PLUS your PROJECT commands, and this also means the CLI can be tailored on a per-project basis.

## Usage
The default `.lorerc` file looks like this:

```js
{
  "generators": {
    "language": "es5"
  }
}
```

A `.lorerc` file that completely replaces the current set of CLI commands looks like this:

```js
{
  "generators": {
    "language": "es5"
  },
  "commands": {
    "new": "lore-generate-new",
    "extract": {
      "description": "Create files that mirror the blueprint behavior",
      "commands": {
        "action": "lore-extract-action",
        "reducer": "lore-extract-reducer"
      }
    },
    "generate": {
      "description": "Generate common project files",
      "commands": {
        "collection": "lore-generate-collection",
        "component": "lore-generate-component",
        "generator": "lore-generate-generator",
        "model": "lore-generate-model",
        "reducer": "lore-generate-reducer",
        "surge": "lore-generate-surge",
        "github": "lore-generate-github",
        "tutorial": "lore-generate-tutorial"
      }
    }
  }
}
```

The new `commands` key is how you signal to the CLI that you have something you need to add to it.

If you want to add a command at the root, such as `lore hello <arguments>`, you would add it by specifying a key called "hello" with a value pointing to the module location:

```js
{
  "generators": {
    "language": "es5"
  },
  "commands": {
    "hello": "./commands/folder-name"
  }
}
```

The value can be a relative path like `./commands/folder-name`, an absolute path like `/Users/jason/some-folder/command-folder`, or a node_module like `module-name`. If you provide a node_module, the CLI will first look in the project's node_modules directory, and then look in the global node_modules directory before throwing an error if it can't find it in either location.

If you want to create a nested command, like `lore hello world <arguments>` then you need to nest your command inside a category, like this:

```js
{
  "generators": {
    "language": "es5"
  },
  "commands": {
     "description": "Describe what commands in this category are for",
    "hello": {
      "world": "./commands/folder-name"
    }
  }
}
```

The category description is completely optional. It defaults to an empty string. If you specify a description for a category that exists by default, such as `extract` or `generate` it will override the default description.

## Creating New Commands
The CLI has a command called `lore generate generator <generator name>` that will create a folder pre-configured as a working plugin for the Lore CLI. You can use this as a starting point for creating your own commands.

Additional documentation and videos about creating new commands will be added to the website in the future.

## Debugging Module Loading
If you need to debug the module loading sequence for commands, you can add a `debugLoading` key in the `options` object of the `.lorerc` file. I

```js
{
  "generators": {
    "language": "es5"
  },
  "options": {
    "debugLoading": true
  }
}
```

All if does is print out the directory of the modules it's loading. Not necessarily that useful, but better than nothing for now:

```
Loading absolute module: /Users/jason/lore/packages/lore-cli/node_modules/lore-extract-action
Loading absolute module: /Users/jason/lore/packages/lore-cli/node_modules/lore-extract-reducer
Loading directory module: ../../packages/lore-extract-action
Loading project module: lore-generate-collection
Loading project module: lore-generate-component
```