### PR TITLE
Improve multi-api support & specify casing style of API endpoints

### DIFF
--- a/packages/lore-generate-hook/templates/package.json
+++ b/packages/lore-generate-hook/templates/package.json
@@ -2,7 +2,7 @@
   "name": "<%= hookName %>",
   "version": "0.1.0",
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "description": "A hook for Lore",
   "keywords": [
     "lore",

--- a/packages/lore-hook-collections/test/defaultConnection.js
+++ b/packages/lore-hook-collections/test/defaultConnection.js
@@ -1,0 +1,8 @@
+module.exports = {
+  apiRoot: 'https://api.example.com',
+  pluralize: true,
+  casingStyle: 'camel',
+  // headers: function() {},
+  models: {},
+  collections: {}
+};

--- a/packages/lore-hook-collections/test/defaults.spec.js
+++ b/packages/lore-hook-collections/test/defaults.spec.js
@@ -7,7 +7,9 @@ describe('defaults', function() {
   it('should have the correct fields', function() {
     var hook = new Hook(definition);
     var defaultConfig = {
-      collections: {}
+      collections: {
+        defaultConnection: 'default'
+      }
     };
     expect(hook.defaults).to.deep.equal(defaultConfig);
   });

--- a/packages/lore-hook-collections/test/generateProperties.spec.js
+++ b/packages/lore-hook-collections/test/generateProperties.spec.js
@@ -2,11 +2,17 @@ var expect = require('chai').expect;
 var _ = require('lodash');
 var generateProperties = require('../src/generateProperties');
 var Hook = require('lore-utils').Hook;
+var defaultConnection = require('./defaultConnection');
+
+function url(route) {
+  return defaultConnection.apiRoot +route;
+}
 
 describe('generateProperties', function() {
 
   it('should remove properties from /models/:definition', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       modelDefinition: {
         properties: {
           url: 'https://models.todo/todos'
@@ -14,12 +20,13 @@ describe('generateProperties', function() {
       }
     });
     expect(properties).to.deep.equal({
-      url: '/todo'
+      url: defaultConnection.apiRoot + '/todos'
     });
   });
 
   it('should remove properties from /config/models', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       modelsConfig: {
         properties: {
           url: 'https://config.models/todos'
@@ -27,12 +34,13 @@ describe('generateProperties', function() {
       }
     });
     expect(properties).to.deep.equal({
-      url: '/todo'
+      url: defaultConnection.apiRoot + '/todos'
     });
   });
 
   it('should create url from apiRoot and pluralize settings', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       modelsConfig: {
         apiRoot: 'https://config.collections',
         pluralize: true
@@ -43,6 +51,7 @@ describe('generateProperties', function() {
 
   it('config/collections takes priority over config/models', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       collectionsConfig: {
         apiRoot: 'https://config.collections'
       },
@@ -50,11 +59,12 @@ describe('generateProperties', function() {
         apiRoot: 'https://config.models'
       }
     });
-    expect(properties.url).to.equal('https://config.collections/todo');
+    expect(properties.url).to.equal('https://config.collections/todos');
   });
 
   it('models/todo takes priority over config/collections', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       collectionsConfig: {
         apiRoot: 'https://config.collections'
       },
@@ -62,11 +72,12 @@ describe('generateProperties', function() {
         apiRoot: 'https://models.todo'
       }
     });
-    expect(properties.url).to.equal('https://models.todo/todo');
+    expect(properties.url).to.equal('https://models.todo/todos');
   });
 
   it('collections/todo takes priority over models/todo', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       collectionDefinition: {
         apiRoot: 'https://collections.todo'
       },
@@ -74,11 +85,12 @@ describe('generateProperties', function() {
         apiRoot: 'https://models.todo'
       }
     });
-    expect(properties.url).to.equal('https://collections.todo/todo');
+    expect(properties.url).to.equal('https://collections.todo/todos');
   });
 
   it('should pass properties along', function() {
     var properties = generateProperties('todo', {
+      connection: _.extend({}, defaultConnection),
       collectionsConfig: {
         properties: {
           propA: 'a'
@@ -93,7 +105,7 @@ describe('generateProperties', function() {
     expect(properties).to.deep.equal({
       propA: 'a',
       propB: 'b',
-      url: '/todo'
+      url: defaultConnection.apiRoot + '/todos'
     });
   });
 

--- a/packages/lore-hook-collections/test/load.spec.js
+++ b/packages/lore-hook-collections/test/load.spec.js
@@ -6,6 +6,7 @@ var definition = require('../src/index');
 var loaderHelper = require('../../lore/test/helpers/loaderHelper');
 var loader = require('../../lore/src/loader');
 var Hook = require('lore-utils').Hook;
+var defaultConnection = require('./defaultConnection');
 
 describe('load', function() {
   var lore = null;
@@ -14,11 +15,17 @@ describe('load', function() {
 
   beforeEach(function() {
     hook = new Hook(definition);
-    defaultConfig = hook.defaults;
+    defaultConfig = hook.defaults.collections;
 
     lore = {
+      connections: {
+        default: defaultConnection
+      },
       config: {
-        collections: defaultConfig
+        collections: defaultConfig,
+        models: {
+          defaultConnection: 'default'
+        }
       },
       loader: loader({})
     };

--- a/packages/lore-hook-connections/README.md
+++ b/packages/lore-hook-connections/README.md
@@ -1,0 +1,5 @@
+# lore-hook-connections
+
+### Purpose
+
+A lore hook that stores connection information for supporting multiple APIs.

--- a/packages/lore-hook-connections/package.json
+++ b/packages/lore-hook-connections/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lore-hook-connections",
+  "version": "0.10.0",
+  "license": "MIT",
+  "main": "./lib/index.js",
+  "description": "A lore hook that stores connection information for multiple APIs",
+  "keywords": [
+    "lore",
+    "hook"
+  ],
+  "scripts": {
+    "build": "../../node_modules/.bin/babel src --out-dir lib",
+    "clean": "rimraf lib",
+    "debug": "mocha debug --compilers js:babel-core/register --recursive",
+    "prepublish": "npm run build",
+    "test": "mocha --compilers js:babel-core/register test/bootstrap.js test/**/*.spec.js --recursive"
+  },
+  "dependencies": {
+    "lodash": "^4.0.0",
+    "lore-utils": "~0.10.0"
+  },
+  "devDependencies": {
+    "chai": "3.4.1",
+    "mocha": "2.3.4"
+  }
+}

--- a/packages/lore-hook-connections/src/index.js
+++ b/packages/lore-hook-connections/src/index.js
@@ -1,0 +1,31 @@
+var _ = require('lodash');
+
+var defaultConnectionData = {
+  apiRoot: 'https://api.example.com',
+  pluralize: true,
+  casingStyle: 'camel',
+  // headers: function() {},
+  models: {},
+  collections: {}
+};
+
+module.exports = {
+
+  dependencies: [],
+
+  defaults: {
+    connections: {
+      default: _.extend({}, defaultConnectionData)
+    }
+  },
+
+  load: function(lore) {
+    var config = lore.config.connections;
+    lore.connections = {};
+
+    _.mapKeys(config, function(data, connectionName) {
+      lore.connections[connectionName] = _.extend({}, defaultConnectionData, data);
+    });
+  }
+
+};

--- a/packages/lore-hook-connections/test/bootstrap.js
+++ b/packages/lore-hook-connections/test/bootstrap.js
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------
+// Mock out all file loaders so we don't need physical files for testing
+// ---------------------------------------------------------------------
+var loaderHelper = require('../../lore/test/helpers/loaderHelper');
+
+beforeEach(function() {
+  loaderHelper.init();
+});
+
+afterEach(function() {
+  loaderHelper.restore();
+});
+
+// --------------------------------------------------
+// Set up Nock to block and mock out network requests
+// --------------------------------------------------
+// var nock = require('nock');
+//
+// before(function(){
+//   nock.disableNetConnect();
+// });
+//
+// afterEach(function(){
+//   nock.cleanAll();
+// });
+//
+// after(function(){
+//   nock.restore();
+// });

--- a/packages/lore-hook-connections/test/defaults.spec.js
+++ b/packages/lore-hook-connections/test/defaults.spec.js
@@ -7,9 +7,15 @@ describe('defaults', function() {
   it('should have the correct fields', function() {
     var hook = new Hook(definition);
     var defaultConfig = {
-      models: {
-        defaultConnection: 'default',
-        connectionModelMap: {},
+      connections: {
+        default: {
+          apiRoot: 'https://api.example.com',
+          pluralize: true,
+          casingStyle: 'camel',
+          // headers: function() {},
+          models: {},
+          collections: {}
+        }
       }
     };
     expect(hook.defaults).to.deep.equal(defaultConfig);

--- a/packages/lore-hook-models/src/generateProperties.js
+++ b/packages/lore-hook-models/src/generateProperties.js
@@ -2,39 +2,75 @@ var pluralize = require('pluralize');
 var defaultsDeep = require('merge-defaults');
 var _ = require('lodash');
 
-function conventionProperties(modelName, config) {
-  var apiRoot = config.apiRoot;
+var CasingStyles = {
+  Camel: 'camel',
+  Snake: 'snake',
+  Kebab: 'kebab',
+  Pascal: 'pascal'
+};
 
-  if (config.pluralize) {
-    return {
-      urlRoot: apiRoot ? apiRoot + '/' + pluralize(modelName) : pluralize(modelName)
-    }
-  }
-
-  return {
-    urlRoot: apiRoot ? apiRoot + '/' + modelName : '/' + modelName
+function applyCasingStyle(casingStyle, modelName) {
+  switch (casingStyle) {
+    case CasingStyles.Camel:
+      return _.camelCase(modelName);
+    case CasingStyles.Kebab:
+      return _.kebabCase(modelName);
+    case CasingStyles.Pascal:
+      return _.upperFirst(_.camelCase(modelName));
+    case CasingStyles.Snake:
+      return _.snakeCase(modelName);
+    default:
+      throw new Error(`Illegal casingStyle of '${casingStyle}' provided. Must be one of [${[
+        CasingStyles.Camel,
+        CasingStyles.Kebab,
+        CasingStyles.Pascal,
+        CasingStyles.Snake
+      ]}]`);
   }
 }
 
+function getUrlRoot(modelName, config) {
+  var apiRoot = config.apiRoot;
+  var isPlural = config.pluralize;
+  var casingStyle = config.casingStyle;
+  var endpoint = config.endpoint;
+
+  // if the user did not provide a custom endpoint, generate
+  // one from the model name
+  if (!endpoint) {
+    endpoint = isPlural ?
+      applyCasingStyle(casingStyle, pluralize(modelName)) :
+      applyCasingStyle(casingStyle, modelName);
+  }
+
+  return apiRoot ? apiRoot + '/' + endpoint : endpoint;
+}
+
 module.exports = function(modelName, options) {
+  var connection = options.connection || {};
   var config = options.config || {};
   var definition = options.definition || {};
 
   /**
-   * Build conventions from config and collection definition. The config that
-   * drives conventions is built from the apiRoot and pluralize fields in:
-   * 1. collections/collectionName.js
-   * 2. config/collections.js
+   * Merge apiRoot, pluralize and casingStyle from config files for
+   * connections, models and the individual model definition
    */
-  var conventionConfig = _.merge({}, config, definition);
+  var combinedConfig = _.merge({}, connection, config, definition);
   var conventions = {
-    properties: conventionProperties(modelName, conventionConfig)
+    properties: {
+      urlRoot: getUrlRoot(modelName, combinedConfig)
+    }
   };
+
+  if (connection.headers) {
+    conventions.properties.headers = connection.headers;
+  }
 
   // Build the final set of properties for the collection
   var properties = {};
   defaultsDeep(properties, definition.properties);
   defaultsDeep(properties, config.properties);
+  defaultsDeep(properties, connection.models.properties);
   defaultsDeep(properties, conventions.properties);
 
   return properties;

--- a/packages/lore-hook-models/src/index.js
+++ b/packages/lore-hook-models/src/index.js
@@ -2,19 +2,40 @@ var LoreModels = require('lore-models');
 var _ = require('lodash');
 var generateProperties = require('./generateProperties');
 
+function getConnectionName(config, modelName) {
+  var connection = config.defaultConnection;
+  var connectionModelMap = config.connectionModelMap;
+
+  _.mapKeys(connectionModelMap, function(models, connectionName) {
+    if (models.indexOf(modelName) >= 0) {
+      connection = connectionName;
+    }
+  });
+
+  return connection;
+}
+
 module.exports = {
+  dependencies: ['connections'],
 
   defaults: {
     models: {
-      apiRoot: 'https://api.example.com',
-      pluralize: true,
-      properties: {}
+      defaultConnection: 'default',
+      // apiRoot: 'https://api.example.com',
+      // pluralize: true,
+      // properties: {},
+      // endpoint: 'custom_non-model_name',
+      // models: {}
+      connectionModelMap: {
+        // default: [...model names...]
+      }
     }
   },
 
   load: function(lore) {
     var models = lore.loader.loadModels();
     var config = lore.config.models;
+    var connections = lore.connections;
     lore.models = {};
 
     _.mapKeys(models, function(module, moduleName) {
@@ -22,12 +43,16 @@ module.exports = {
       // should change to be PascalCase, like lore.models.ModelName
       var modelName = moduleName;
 
+      // get the connection for this model
+      var connection = connections[getConnectionName(config, modelName)];
+
       // Cascaded series of defaults to define the models final properties
       // 1. Start from anything the user defined in the collections's config
       // 2. Add any missing application level settings from config.models
       // 2. Add any missing settings from conventions
       var properties = generateProperties(modelName, {
         config: config,
+        connection: connection,
         definition: module
       });
 

--- a/packages/lore-hook-models/test/defaultConnection.js
+++ b/packages/lore-hook-models/test/defaultConnection.js
@@ -1,0 +1,8 @@
+module.exports = {
+  apiRoot: 'https://api.example.com',
+  pluralize: true,
+  casingStyle: 'camel',
+  // headers: function() {},
+  models: {},
+  collections: {}
+};

--- a/packages/lore-hook-models/test/generateProperties.spec.js
+++ b/packages/lore-hook-models/test/generateProperties.spec.js
@@ -2,11 +2,13 @@ var expect = require('chai').expect;
 var _ = require('lodash');
 var generateProperties = require('../src/generateProperties');
 var Hook = require('lore-utils').Hook;
+var defaultConnection = require('./defaultConnection');
 
 describe('generateProperties', function() {
 
   it('should create urlRoot from apiRoot and pluralize settings', function() {
     var properties = generateProperties('todo', {
+      connection: defaultConnection,
       config: {
         apiRoot: 'https://config.models',
         pluralize: true
@@ -17,6 +19,7 @@ describe('generateProperties', function() {
 
   it('models/todo takes priority over config/models', function() {
     var properties = generateProperties('todo', {
+      connection: defaultConnection,
       config: {
         apiRoot: 'https://config.models'
       },
@@ -24,11 +27,12 @@ describe('generateProperties', function() {
         apiRoot: 'https://models.todo'
       }
     });
-    expect(properties.urlRoot).to.equal('https://models.todo/todo');
+    expect(properties.urlRoot).to.equal('https://models.todo/todos');
   });
 
   it('should pass properties along', function() {
     var properties = generateProperties('todo', {
+      connection: defaultConnection,
       config: {
         properties: {
           propA: 'a'
@@ -43,7 +47,7 @@ describe('generateProperties', function() {
     expect(properties).to.deep.equal({
       propA: 'a',
       propB: 'b',
-      urlRoot: '/todo'
+      urlRoot: defaultConnection.apiRoot + '/todos'
     });
   });
 

--- a/packages/lore-hook-models/test/load.spec.js
+++ b/packages/lore-hook-models/test/load.spec.js
@@ -5,6 +5,7 @@ var loaderHelper = require('../../lore/test/helpers/loaderHelper');
 var loader = require('../../lore/src/loader');
 var Model = require('lore-models').Model;
 var Hook = require('lore-utils').Hook;
+var defaultConnection = require('./defaultConnection');
 
 describe('load', function() {
   var lore = null;
@@ -16,6 +17,9 @@ describe('load', function() {
     defaultConfig = hook.defaults.models;
 
     lore = {
+      connections: {
+        default: _.extend({}, defaultConnection)
+      },
       config: {
         models: defaultConfig
       },

--- a/packages/lore/package.json
+++ b/packages/lore/package.json
@@ -43,6 +43,7 @@
     "lore-hook-actions": "~0.10.0",
     "lore-hook-bind-actions" : "~0.10.0",
     "lore-hook-collections": "~0.10.0",
+    "lore-hook-connections": "~0.10.0",
     "lore-hook-connect": "~0.10.0",
     "lore-hook-dialog": "~0.10.0",
     "lore-hook-models": "~0.10.0",

--- a/packages/lore/src/loaders/config.js
+++ b/packages/lore/src/loaders/config.js
@@ -1,11 +1,14 @@
 var buildDictionary = require('webpack-requiredir');
+var _ = require('lodash');
 
 // 'config/*'
 function loadOtherConfigFiles() {
-  var context = require.context(__LORE_ROOT__ + '/config', false, /\.js$/);
-  return buildDictionary(context, {
+  var context = require.context(__LORE_ROOT__ + '/config', true, /\.js$/);
+  var config = buildDictionary(context, {
     exclude: ['local.js']
   });
+
+  return _.omit(config, 'env');
 }
 
 // 'config/local'

--- a/packages/lore/test/defaultHooks.js
+++ b/packages/lore/test/defaultHooks.js
@@ -2,6 +2,7 @@ module.exports = {
   actions: require("lore-hook-actions"),
   bindActions: require("lore-hook-bind-actions"),
   collections: require("lore-hook-collections"),
+  connections: require("lore-hook-connections"),
   connect: require("lore-hook-connect"),
   dialog: require("lore-hook-dialog"),
   models: require("lore-hook-models"),

--- a/packages/lore/test/helpers/loaderHelper.js
+++ b/packages/lore/test/helpers/loaderHelper.js
@@ -5,6 +5,7 @@ var sinon = require('sinon');
 var loaders = {
   actions: require('../../src/loaders/actions'),
   collections: require('../../src/loaders/collections'),
+  connections: { load: function(){} },
   config: require('../../src/loaders/config'),
   models: require('../../src/loaders/models'),
   reducers: require('../../src/loaders/reducers'),


### PR DESCRIPTION
This PR addresses addresses #135 and #141.

# Improved Multi-API Support
Currently the framework assumes a single API server (specified in `config/models.js` as `apiRoot`) and then lets you override it on a per-model basis. This is a bad development experience because it means every model on the second server has to override `apiRoot`.

### Specifying a single API
This PR introduces a concept called `connections` that makes multi-API support a first-class feature. Instead of specifying the `apiRoot` in `config/models.js` you create a `connection` in `config/connections.js` that looks like this:

```js
// config/connections.js
{
  default: {
    apiRoot: 'https://api.myapp.com',
    
    pluralize: true,
    
    casingStyle: 'snake',
    
    headers: function() {
      return {
        'Authorization': 'Token XYZ'
      };
    },
    
    models: {
      properties: {
        generateCid: function() {...},
        parse: function(attributes) {...}
      }
    },

    collections: {
      properties: {
        parse: function(attributes) {...}
      }
    }
  }
}
```

This file declares a named connection called `default`, representing the default API server. Most of the functionality in `config/model.js` has been moved into this file. One advantage of doing this is that `headers` can now be declared in only one location, and applied to `Models` and `Collections` without duplication.

To use this connection, you specify it as the default in `config/models`, like this:

```js
// config/models.js
{
  defaultConnection: 'default'
}
```

### Adding additional API servers
With this approach supporting multiple APIs is easy, as you can add additional connections and map them to models. For example, let's say we have an app developed using the `default` connection, and the API started migrating to v2. In this case, we could rename our `default` connection to `v1` and add a second connection for `v2` like this:

```js
// config/connections.js
{
  v1: {...},
  v2: {...}
}
```

Then in `config/models.js` we rename the default and provide a map of which models use the non-default connection like this:

```js
// config/models.js
{
  defaultConnection: 'v1',
  connectionModelMap: {
    // v1: [...optional...],
    v2: [
      'post',
      'comment',
      'modelThree'
    ]
  }
}
```

If you want to be explicit you can map all models, but models are assumed to be associated with the `defaultConnection` unless otherwise declared. This also gives a single location in the project to view which models are connected to which API endpoints.


# Specify casing style of API servers
Currently the project assumes the API server uses a camelCase casing style, such as `/api/userComments` or `/api/bookAuthors`. But some APIs (like Django and Rails) use a snake_case style, like `/api/user_comments`, and others use a kebab-case style like `/api/user-comments`. This requires the user to override the `urlRoot` on every model that is affected by the camelCase style.

This PR allows users to specify the casing style as part of the connection, like this:

```js
// config/connections.js
{
  default: {
    apiRoot: 'https://api.myapp.com',
    
    // options: camel, kebab, snake, pascal
    casingStyle: 'camel',
  }
}
```

Changing the casingStyle from the default `camel` to any other style will convert URLs to that style, e.g. 

```js
{
  camel: `/api/userComments`,
  kebab: `/api/user-comments`,
  snake: `/api/user_comments`,
  pascal: `/api/UserComments`
}
```

Generally speaking, `camel` and `pascal` are the same thing, as URLs are case-insensitive, but the user way to prefer to see networks requests in one style of the other, so both are supported.