### PR TITLE
[lore] use loader for config generation

### DIFF
--- a/packages/lore/src/app/getConfig.js
+++ b/packages/lore/src/app/getConfig.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var configLoader = require('../loaders/config');
 
 function getDefaultConfig(hooks) {
   return _.reduce(hooks, function(result, value, key) {
@@ -22,8 +21,8 @@ function getDefaultConfig(hooks) {
  * passed object, and builds a state object with the same shape.
  */
 
-module.exports = function getConfig(configOverride, hooks, env) {
+module.exports = function getConfig(configOverride, hooks, loader) {
   var defaultConfig = getDefaultConfig(hooks);
-  var userConfig = configLoader.load(env);
+  var userConfig = loader.loadUserConfig();
   return _.merge({}, defaultConfig, userConfig, configOverride);
 };

--- a/packages/lore/src/app/index.js
+++ b/packages/lore/src/app/index.js
@@ -64,7 +64,7 @@ _.extend(Lore.prototype, {
     // Generate the final config from the combination of the overrides passed
     // into the app, the default config (calculated from the hooks), and the
     // user config for the project (loaded and compiled inside this function)
-    this.config = getConfig(configOverride, this.hooks, this.environment);
+    this.config = getConfig(configOverride, this.hooks, this.loader);
 
     // Get initializers and run them
     this.initializers = getInitializers();


### PR DESCRIPTION
This PR resolves #87.

It uses the `loader` to generate the config instead using the environment to invoke to the config file loader directly.