### PR TITLE
[hook] add router hook

### DIFF
--- a/packages/lore-hook-router/README.md
+++ b/packages/lore-hook-router/README.md
@@ -1,0 +1,5 @@
+# lore-hook-router
+
+### Purpose
+
+A hook for generating files for a Lore project.

--- a/packages/lore-hook-router/package.json
+++ b/packages/lore-hook-router/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "lore-hook-polling",
-  "version": "0.11.3",
+  "name": "lore-hook-router",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "lib/index.js",
-  "description": "A Lore hook that enables polling of action",
+  "description": "A hook for Lore",
   "keywords": [
     "lore",
     "hook",
-    "polling"
+    "router",
+    "react-router"
   ],
   "scripts": {
     "build": "../../node_modules/.bin/babel src --out-dir lib",
@@ -16,12 +17,13 @@
     "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register test/bootstrap.js test/**/*.spec.js --recursive"
   },
-  "dependencies": {
-    "lodash": "^4.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "chai": "3.4.1",
-    "lore-utils": "^0.11.0",
-    "mocha": "2.3.4"
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4",
+    "react-router": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react-router": "^3.0.0"
   }
 }

--- a/packages/lore-hook-router/src/index.js
+++ b/packages/lore-hook-router/src/index.js
@@ -1,0 +1,24 @@
+var browserHistory = require('react-router').browserHistory;
+
+module.exports = {
+
+  dependencies: ['connect'],
+
+  defaults: {
+    router: {
+      history: browserHistory,
+      routes: function(lore) {
+        return lore.loader.loadRoutes();
+      }
+    }
+  },
+
+  load: function(lore) {
+    var config = lore.config.router;
+    lore.router = {
+      history: config.history,
+      routes: config.routes(lore)
+    }
+  }
+
+};

--- a/packages/lore-hook-router/test/test.spec.js
+++ b/packages/lore-hook-router/test/test.spec.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('an empty spec', function() {
+  it('passes', function() {
+    expect(true).to.eq(true);
+  });
+});


### PR DESCRIPTION
This PR adds an official router hook. This will be used to remove the lore's control over router creation and loading of routes (which is currently owned by the lore core).

This hook also takes formal control of the `config/router.js` file, and adds the ability to control where routes are stored in the application.

```js
 /**
  * This file is where you define overrides for the default routing behavior.
  **/

var browserHistory = require('react-router').browserHistory;

module.exports = {

  /**
   * Whether browser should use pushState or hash to keep track of routes
   * See: https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md
   **/

  history: browserHistory,

  /**
   * Returns the routes used by the application.
   *
   * The 'lore.loader' object is a way of lazy-loading files and directories the framework
   * doesn't have control over such as the models, config directory, and in this case the
   * routes.js file at the root of the project.
   *
   * The reason the loader is used here is because the routes _must_ to be lazy-loaded,
   * since loading the routes will pull in the components, which may be using the
   * 'lore.connect' decorator that won't exist until the 'connect' hooks loads.
   *
   * Trying to load the routes directly in this config file will throw an error during
   * build, because lore loads the config file _before_ any of the hooks, since they
   * need information in the config to determine their behavior.
   */

  routes: function(lore) {
    return lore.loader.loadRoutes();
  }

};

```

