### PR TITLE
[lore-hook-actions] add normalization support

### DIFF
--- a/packages/lore-extract-action/templates/es5/get.js
+++ b/packages/lore-extract-action/templates/es5/get.js
@@ -2,22 +2,33 @@ var _ = require('lodash');
 var ActionTypes = require('lore-utils').ActionTypes;
 var PayloadStates = require('lore-utils').PayloadStates;
 var payload = require('lore-utils').payload;
+var normalize = require('lore-hook-actions/lib/normalize');
 
 /*
  * Blueprint for Get method
  */
-module.exports = function get(modelId) {
+module.exports = function get(modelId, query) {
   return function(dispatch) {
     var Model = lore.models.<%= modelName %>;
     var model = new Model({
       id: modelId
     });
+    query = query || {};
 
-    model.fetch().then(function() {
+    model.fetch({
+      data: query
+    }).then(function() {
+      // look through the model and generate actions for any attributes with
+      // nested data that should be normalized
+      var actions = normalize(lore, '<%= modelName %>').model(model);
+
       dispatch({
         type: ActionTypes.update('<%= modelName %>'),
         payload: payload(model, PayloadStates.RESOLVED)
       });
+
+      // dispatch any actions created from normalizing nested data
+      actions.forEach(dispatch);
     }).catch(function(response) {
       var error = response.data;
 

--- a/packages/lore-extract-action/templates/es6/find.js
+++ b/packages/lore-extract-action/templates/es6/find.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { ActionTypes, PayloadStates, payloadCollection } from 'lore-utils';
-
+import normalize from 'lore-hook-actions/lib/normalize';
 /*
  * Blueprint for Find method
  */
@@ -20,11 +20,18 @@ export default function find(query = {}, pagination) {
     collection.fetch({
       data: queryParameters
     }).then(function() {
+      // look through all models in the collection and generate actions for any attributes
+      // with nested data that should be normalized
+      const actions = normalize(lore, '<%= modelName %>').collection(collection);
+
       dispatch({
         type: ActionTypes.fetchPlural('<%= modelName %>'),
         payload: payloadCollection(collection, PayloadStates.RESOLVED, null, combinedQuery),
         query: combinedQuery
       });
+
+      // dispatch any actions created from normalizing nested data
+      actions.forEach(dispatch);
     }).catch(function(response) {
       const error = response.data;
 

--- a/packages/lore-hook-actions/src/blueprints/find.js
+++ b/packages/lore-hook-actions/src/blueprints/find.js
@@ -1,7 +1,8 @@
 var ActionTypes = require('lore-utils').ActionTypes;
 var PayloadStates = require('lore-utils').PayloadStates;
+var normalize = require('../normalize');
 
-module.exports = function(collectionName, collections) {
+module.exports = function(collectionName, collections, lore) {
 
   var Collection = collections[collectionName];
 
@@ -23,6 +24,21 @@ module.exports = function(collectionName, collections) {
     onError: {
       actionType: ActionTypes.fetchPlural(collectionName),
       payloadState: PayloadStates.ERROR_FETCHING
+    },
+
+    normalize: {
+
+      // look through all models in the collection and generate actions for any attributes
+      // with nested data that should be normalized
+      getActions: function(collection) {
+        return normalize(lore, collectionName).collection(collection);
+      },
+
+      // dispatch any actions created from normalizing nested data
+      dispatchActions: function(actions, dispatch) {
+        actions.forEach(dispatch);
+      }
+
     }
 
   };

--- a/packages/lore-hook-actions/src/blueprints/get.js
+++ b/packages/lore-hook-actions/src/blueprints/get.js
@@ -1,7 +1,8 @@
 var ActionTypes = require('lore-utils').ActionTypes;
 var PayloadStates = require('lore-utils').PayloadStates;
+var normalize = require('../normalize');
 
-module.exports = function(modelName, models) {
+module.exports = function(modelName, models, lore) {
 
   var Model = models[modelName];
 
@@ -28,7 +29,23 @@ module.exports = function(modelName, models) {
     onNotFound: {
       actionType: ActionTypes.update(modelName),
       payloadState: PayloadStates.NOT_FOUND
+    },
+
+    normalize: {
+
+      // look through the model and generate actions for any attributes with
+      // nested data that should be normalized
+      getActions: function(model) {
+        return normalize(lore, modelName).model(model);
+      },
+
+      // dispatch any actions created from normalizing nested data
+      dispatchActions: function(actions, dispatch) {
+        actions.forEach(dispatch);
+      }
+
     }
+
   }
 };
 

--- a/packages/lore-hook-actions/src/index.js
+++ b/packages/lore-hook-actions/src/index.js
@@ -2,14 +2,6 @@ var _ = require('lodash');
 var actionBlueprints = require('lore-actions').blueprints;
 var utils = require('lore-actions').utils;
 
-var blueprints = {
-  create: require('./blueprints/create'),
-  destroy: require('./blueprints/destroy'),
-  get: require('./blueprints/get'),
-  find: require('./blueprints/find'),
-  update: require('./blueprints/update')
-};
-
 function convertBlueprintToActionCreator(action, store) {
   // if the module isn't a function, then it's an object describing the action
   // config and needs to be converted to a real function
@@ -40,8 +32,16 @@ module.exports = {
 
   defaults: {
     actions: {
+      normalize: true,
       addCidToBody: false,
       cidBodyAttributeName: 'cid',
+      blueprints: {
+        create: require('./blueprints/create'),
+        destroy: require('./blueprints/destroy'),
+        get: require('./blueprints/get'),
+        find: require('./blueprints/find'),
+        update: require('./blueprints/update')
+      }
     }
   },
 
@@ -52,6 +52,7 @@ module.exports = {
     var store = lore.store;
     var actions = lore.loader.loadActions();
     var config = lore.config.actions;
+    var blueprints = config.blueprints;
 
     // todo: should actions be created for files in /collections
     // that have no corresponding model in /models Currently
@@ -62,8 +63,8 @@ module.exports = {
       _.assign(lore.actions[modelName], {
         create: blueprints.create(modelName, models, config),
         destroy: blueprints.destroy(modelName, models),
-        get: blueprints.get(modelName, models),
-        find: blueprints.find(modelName, collections),
+        get: blueprints.get(modelName, models, lore),
+        find: blueprints.find(modelName, collections, lore),
         update: blueprints.update(modelName, models)
       })
     });

--- a/packages/lore-hook-actions/src/normalize.js
+++ b/packages/lore-hook-actions/src/normalize.js
@@ -1,0 +1,75 @@
+var _ = require('lodash');
+var ActionTypes = require('lore-utils').ActionTypes;
+var PayloadStates = require('lore-utils').PayloadStates;
+var payload = require('lore-utils').payload;
+
+module.exports = function(lore, modelName) {
+  var config = lore.loader.loadModels()[modelName];
+  var Models = lore.models;
+  var shouldNormalize = lore.config.actions.normalize;
+  var attributes = config.attributes || {};
+
+  function normalize(actions, model) {
+    // if normalization is disabled, bail out
+    if (!shouldNormalize) return;
+
+    // iterate over attributes in the model config, looking for any models that need to be normalized
+    _.mapKeys(attributes, function(attribute, attributeName) {
+
+      // if the attribute type isn't a model, we don't care, so bail out
+      if (attribute.type !== 'model') return;
+
+      // get the data we need to inspect for normalization
+      var data = model.attributes[attributeName];
+
+      // if the data is NOT a plain object, we can't normalize it, so bail out
+      if (!_.isPlainObject(data)) return;
+
+      // get the name and instance of the model we need to normalize the attribute to
+      var normalizedModelName = attribute.model;
+
+      // log an error if no model was specified
+      if (!normalizedModelName) {
+        console.error('Attempted to normalize a [' + modelName + '] model but failed. No model name provided for the [' + attributeName + '] attribute');
+        return;
+      }
+
+      // get the model this attribute should be normalized to
+      var NormalizedModel = Models[normalizedModelName];
+
+      // log an error if the model doesn't exist
+      if (!NormalizedModel) {
+        console.error('Attempted to normalize the [' + attributeName + '] for a [' + modelName + '] model but failed. No model exists named [' + normalizedModelName + ']');
+        return;
+      }
+
+      // create an instance of the normalized model populated with the nested data
+      var normalizedModel = new NormalizedModel(data);
+
+      // replace the attribute with it's normalized form (a reference to the id)
+      model.set(attributeName, normalizedModel.id);
+
+      // add an action to be dispatched
+      actions.push({
+        type: ActionTypes.update(normalizedModelName),
+        payload: payload(normalizedModel, PayloadStates.RESOLVED)
+      });
+    })
+  }
+
+  return {
+    model: function(model) {
+      var actions = [];
+      normalize(actions, model);
+      return actions;
+    },
+
+    collection: function(collection) {
+      var actions = [];
+      collection.models.forEach(function(model){
+        normalize(actions, model);
+      });
+      return actions;
+    }
+  }
+};

--- a/packages/lore-hook-actions/test/defaults.spec.js
+++ b/packages/lore-hook-actions/test/defaults.spec.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var definition = require('../src/index');
 var Hook = require('lore-utils').Hook;
+var _ = require('lodash');
 
 describe('defaults', function() {
 
@@ -8,11 +9,41 @@ describe('defaults', function() {
     var hook = new Hook(definition);
     var defaultConfig = {
       actions: {
+        normalize: true,
         addCidToBody: false,
         cidBodyAttributeName: 'cid',
+        // blueprints : {
+        //   create: function() {...},
+        //   destroy: function() {...},
+        //   find: function() {...},
+        //   get: function() {...},
+        //   update: function() {...},
+        // }
       }
     };
-    expect(hook.defaults).to.deep.equal(defaultConfig);
+
+    expect(_.keys(hook.defaults.actions).length).to.equal(4);
+    expect(hook.defaults.actions).to.include.keys([
+      'normalize',
+      'addCidToBody',
+      'cidBodyAttributeName',
+      'blueprints'
+    ]);
+
+    expect(_.pick(hook.defaults.actions, [
+      'normalize',
+      'addCidToBody',
+      'cidBodyAttributeName'
+    ])).to.deep.equal(defaultConfig.actions);
+
+    expect(_.keys(hook.defaults.actions.blueprints).length).to.equal(5);
+    expect(hook.defaults.actions.blueprints).to.include.keys([
+      'create',
+      'destroy',
+      'find',
+      'get',
+      'update'
+    ]);
   });
 
 });

--- a/packages/lore-hook-actions/test/load.spec.js
+++ b/packages/lore-hook-actions/test/load.spec.js
@@ -19,7 +19,7 @@ describe('load', function() {
 
     lore = {
       config: {
-        actions: defaultConfig
+        actions: defaultConfig.actions
       },
       loader: loader({}),
       store: {
@@ -41,7 +41,7 @@ describe('load', function() {
     beforeEach(function() {
       lore = {
         config: {
-          actions: defaultConfig
+          actions: defaultConfig.actions
         },
         loader: loader({}),
         store: {


### PR DESCRIPTION
This PR adds normalization support to actions, allows you to override action blueprints (globally), and allows you to pass a set of query parameters to `byId`.

## Normalization Support
There is a new parameter in the `config/actions.js` config called `normalize` that looks like this:

```js
// config/actions.js
module.exports = {

  /**
   * Specify whether models should be normalized.
   */

  normalize: true,

  // ...

};
```

This value defaults to true, and signals to Lore that models should be normalized. To enable normalization, you need to describe which attributes of a model might contain nested data. For example, if a tweet might contain nested user data, then you can modify `models/tweet.js` to include a `user` attribute of type `model`, that should be converted to an instance of the `user` model, like this:

```js
// models/tweet.js
module.exports = {

  attributes: {
    user: {
      type: 'model',
      model: 'user'
    }
  },

  // ...

};
```

Which this change in place, let's say you have a component that fetches a list of tweets, and requests the user to be embedded in the response, like this:

```jsx
@lore.connect(function(getState, props){
  return {
    tweets: getState('tweet.find', {
      pagination: {
        page: '1',
        _embed: 'user'
      }
    }
  }
})
```

That call will generate a network request to `/tweets?page=1&_embed=user`, which a response that might look like this:

```js
[
  {
    id: 1,
    text: 'Some text',
    user: {
      id: 3,
     name: 'Crono'
    }
  },
  {
    id: 2,
    text: 'Some other text',
    user: {
      id: 4,
     name: 'Marle'
    }
  },
]
```

Currently, lore will pass the objects around the application, and the data will look *exactly* like the JSON response, such as:

```
{
  id: 1,
  state: 'RESOLVED',
  data: {
    id: 1,
    text: 'Some text',
    user: {
      id: 3,
     name: 'Crono'
    }
  }
}
```

Additionally, the application doesn't know you already fetched the user with the id of 3 (Crono) so if you have any components that require that specific user, and include a `connect` call like this:

```jsx
@lore.connect(function(getState, props){
  return {
    tweets: getState('tweet.byId', {
      id: 3
    })
  }
})
```

a network request will be sent out to `/users/3`, because that user doesn't exist in the Redux store.

Normalization behavior does two things. First, the action creator that parses the original `tweets` response looks through each model, and inspects to config to see if any of the attributes are targets for normalization. If it finds one (such as the `user` attribute we configured), and that attribute *is an object*, if will extract the `user` data from the `tweet`, create a new `User` model with that data (e.g. `var user = new User(tweet.attributes.user)`), and then prepare a second action for dispatch containing data for that user, which will cause that user to be added to the Store.

It will also flatten the tweet, to remove the nested data, which means the model passed around the application will look like this instead:

```js
{
  id: 1,
  state: 'RESOLVED',
  data: {
    id: 1,
    text: 'Some text',
    user: 3
  }
}
```

## Overriding Action Blueprints
This PR also provides the ability to override action blueprints on a global basis. This is useful if we want to completely replace the blueprint behavior for ALL models. You can do this in the `config/actions.js` file by overriding that blueprint in the new `blueprints` property:

```js
// config/actions.js
module.exports = {

  /**
   * Override the default blueprints with a custom implementation
   */
  blueprints: {
    find: require('../blueprints/actions/find'),
    get: require('../blueprints/actions/get')
  },

  // ...

};
```

## Query Params to byId Calls
Finally, this PR includes the ability to provide query parameters to `byId` calls, like this:

```jsx
@lore.connect(function(getState, props){
  return {
    tweets: getState('tweet.byId', {
      id: 3,
      query: {
        _embed: 'user'
      }
    })
  }
})
```

This is helpful if you are requesting a single resource and need to pass query parameters to the API, such as a request to nest additional data. The resulting network call will look like this:

```
/tweets/1?_embed=user
```
