### PR TITLE
[lore-hook-connect] add ability to override blueprints

### DIFF
--- a/packages/lore-hook-connect/src/connect.js
+++ b/packages/lore-hook-connect/src/connect.js
@@ -36,10 +36,10 @@ var _getState = require('./getState');
  * })(React.createClass({...})
  *
  */
-module.exports = function(lore) {
+module.exports = function(actions, blueprints, reducerActionMap) {
 
   // provide getState with a copy of lore so it can access reducer-action map
-  var getState = _getState(lore);
+  var getState = _getState(actions, blueprints, reducerActionMap);
 
   return function connect(select, options = {}) {
     return function(DecoratedComponent) {

--- a/packages/lore-hook-connect/src/getState/convertDefinitionToConnection.js
+++ b/packages/lore-hook-connect/src/getState/convertDefinitionToConnection.js
@@ -2,13 +2,8 @@ var _ = require('lodash');
 var Connection = require('../Connection');
 var MissingBlueprintError = require('../errors/MissingBlueprintError');
 var InvalidBlueprintError = require('../errors/InvalidBlueprintError');
-var blueprints = {
-  find: require('../blueprints/find'),
-  byId: require('../blueprints/byId'),
-  singleton: require('../blueprints/singleton')
-};
 
-module.exports = function convertDefinitionToConnection(stateKey, definition, actions) {
+module.exports = function convertDefinitionToConnection(stateKey, definition, actions, blueprints) {
   var action = definition.action;
   var blueprint = definition.blueprint;
 

--- a/packages/lore-hook-connect/src/getState/getConnection.js
+++ b/packages/lore-hook-connect/src/getState/getConnection.js
@@ -11,13 +11,13 @@ function ConnectionMappingError(stateKey) {
   return error;
 }
 
-module.exports = function getConnection(stateKey, reducerActionMap, actions) {
+module.exports = function getConnection(stateKey, reducerActionMap, actions, blueprints) {
   var definition = reducerActionMap[stateKey] || generateBlueprintFromConventions(stateKey);
 
   if (!definition) {
     throw new ConnectionMappingError(stateKey);
   }
 
-  var connection = convertDefinitionToConnection(stateKey, definition, actions);
+  var connection = convertDefinitionToConnection(stateKey, definition, actions, blueprints);
   return connection;
 };

--- a/packages/lore-hook-connect/src/getState/index.js
+++ b/packages/lore-hook-connect/src/getState/index.js
@@ -1,10 +1,8 @@
 var getConnection = require('./getConnection');
 
-module.exports = function(lore) {
+module.exports = function(actions, blueprints, reducerActionMap) {
   return function (state, stateKey, params, options) {
-    var reducerActionMap = lore.config.connect.reducerActionMap;
-    var actions = lore.actions;
-    var connection = getConnection(stateKey, reducerActionMap, actions);
+    var connection = getConnection(stateKey, reducerActionMap, actions, blueprints);
     return connection.getState(state, params, options);
   };
 };

--- a/packages/lore-hook-connect/src/index.js
+++ b/packages/lore-hook-connect/src/index.js
@@ -6,12 +6,22 @@ module.exports = {
 
   defaults: {
     connect: {
+      blueprints: {
+        find: require('./blueprints/find'),
+        byId: require('./blueprints/byId'),
+        singleton: require('./blueprints/singleton')
+      },
       reducerActionMap: {}
     }
   },
 
   load: function(lore) {
-    lore.connect = connect(lore);
+    var config = lore.config.connect;
+    var actions = lore.actions;
+    var reducerActionMap = config.reducerActionMap;
+    var blueprints = config.blueprints;
+
+    lore.connect = connect(actions, blueprints, reducerActionMap);
   }
 
 };

--- a/packages/lore-hook-connect/test/blueprints/byId.spec.js
+++ b/packages/lore-hook-connect/test/blueprints/byId.spec.js
@@ -2,6 +2,11 @@ var expect = require('chai').expect;
 var _ = require('lodash');
 var sinon = require('sinon');
 var _getState = require('../../src/getState');
+var blueprints = {
+  find: require('../../src/blueprints/find'),
+  byId: require('../../src/blueprints/byId'),
+  singleton: require('../../src/blueprints/singleton')
+};
 
 describe('blueprints#byId', function() {
   var lore, storeState, key, testAction;
@@ -56,7 +61,7 @@ describe('blueprints#byId', function() {
 
     describe('and params are provided', function() {
       it('should call the action', function () {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.byId', {
           id: 1
         });
@@ -110,7 +115,7 @@ describe('blueprints#byId', function() {
       });
 
       it('should return the data and not call the action', function() {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.byId', {
           id: 1
         });

--- a/packages/lore-hook-connect/test/blueprints/find.spec.js
+++ b/packages/lore-hook-connect/test/blueprints/find.spec.js
@@ -3,6 +3,11 @@ var _ = require('lodash');
 var sinon = require('sinon');
 var _getState = require('../../src/getState');
 var toJsonKey = require('../../src/utils/toJsonKey');
+var blueprints = {
+  find: require('../../src/blueprints/find'),
+  byId: require('../../src/blueprints/byId'),
+  singleton: require('../../src/blueprints/singleton')
+};
 
 describe('blueprints#find', function() {
   var lore, storeState, key, testAction;
@@ -50,7 +55,7 @@ describe('blueprints#find', function() {
 
     describe('and no params are provided', function() {
       it('should call the action', function () {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.find');
         expect(payload).to.be.an('object');
         expect(payload.state).to.equal(testAction.payload.state);
@@ -60,7 +65,7 @@ describe('blueprints#find', function() {
 
     describe('and params are provided', function() {
       it('should call the action', function () {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.find', {
           where: {
             author: 1
@@ -106,7 +111,7 @@ describe('blueprints#find', function() {
       });
 
       it('should return the data and not call the action', function() {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.find');
         expect(payload).to.be.an('object');
         expect(payload.state).to.equal(reducerState.state);
@@ -130,7 +135,7 @@ describe('blueprints#find', function() {
       });
 
       it('should return the data and not call the action', function() {
-        var getState = _getState(lore);
+        var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
         var payload = getState(storeState, 'post.find', {
           where: {
             author: 1

--- a/packages/lore-hook-connect/test/defaults.spec.js
+++ b/packages/lore-hook-connect/test/defaults.spec.js
@@ -8,7 +8,12 @@ describe('defaults', function() {
     var hook = new Hook(definition);
     var defaultConfig = {
       connect: {
-        reducerActionMap: {}
+        blueprints: {
+          find: require('../src/blueprints/find'),
+          byId: require('../src/blueprints/byId'),
+          singleton: require('../src/blueprints/singleton')
+        },
+        reducerActionMap: {},
       }
     };
     expect(hook.defaults).to.deep.equal(defaultConfig);

--- a/packages/lore-hook-connect/test/getState.spec.js
+++ b/packages/lore-hook-connect/test/getState.spec.js
@@ -3,15 +3,25 @@ var _ = require('lodash');
 var sinon = require('sinon');
 var _getState = require('../src/getState/index');
 var toJsonKey = require('../src/utils/toJsonKey');
+var blueprints = {
+  find: require('../src/blueprints/find'),
+  byId: require('../src/blueprints/byId')
+};
 
 describe('getState', function() {
   var lore, storeState, key, testAction;
   var findBlueprintAction, byIdBlueprintAction;
 
   beforeEach(function () {
+    var findBlueprintAction = sinon.spy();
+    var byIdBlueprintAction = sinon.spy();
     lore = {
       config: {
         connect: {
+          // blueprints: {
+          //   find: findBlueprintAction,
+          //   byId: byIdBlueprintAction
+          // },
           reducerActionMap: {}
         }
       },
@@ -41,8 +51,6 @@ describe('getState', function() {
       }
     };
 
-    findBlueprintAction = sinon.spy();
-    byIdBlueprintAction = sinon.spy();
     lore.actions.post.find = findBlueprintAction;
     lore.actions.post.get = byIdBlueprintAction;
 
@@ -60,14 +68,14 @@ describe('getState', function() {
   describe('conventions', function() {
 
     it('should use the find blueprint if asking for model.find', function() {
-      var getState = _getState(lore);
+      var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
       var payload = getState(storeState, 'post.find');
       expect(payload).to.be.an('object');
       expect(payload.state).to.equal('RESOLVED');
     });
 
     it('should use the byId blueprint if asking for model.byId', function() {
-      var getState = _getState(lore);
+      var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
       var payload = getState(storeState, 'post.byId', {
         id: 1
       });
@@ -115,7 +123,7 @@ describe('getState', function() {
         blueprint: blueprint
       };
 
-      var getState = _getState(lore);
+      var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
       var payload = getState(storeState, 'currentUser');
       expect(payload).to.be.an('object');
       expect(payload.state).to.equal('RESOLVED');
@@ -132,7 +140,7 @@ describe('getState', function() {
         state: 'RESOLVED'
       };
 
-      var getState = _getState(lore);
+      var getState = _getState(lore.actions, blueprints, lore.config.connect.reducerActionMap);
       var payload = getState(storeState, 'currentUser');
       expect(payload).to.be.an('object');
       expect(payload.state).to.equal('RESOLVED');


### PR DESCRIPTION
This PR adds the ability to override blueprints for mapping reducers to actions. Previously you could override the blueprint for a *specific* mapping, such as `tweet.byId`, but not for ALL `byId` calls at once, such as `tweet.byId`, `user.byId`, etc.

This refactor adds a new property to the `config/connect.js` config called `blueprints` that looks like this:

```js
// config/connect.js
module.exports = {

  /**
   * Extend or override the built-in blueprints. This is helpful if you want to
   * change the interface for 'lore.connect'. For example the default syntax to
   * fetch a model by id looks like this:
   *
   *   getState('tweet.byId', {
   *     id: 1
   *   })
   *
   * If you overrode the blueprint, you could modify the syntax to look like this
   * instead, to match the interface for the 'find' blueprint:
   *
   *   getState('tweet.find', {
   *     where: {
   *       id: 1
   *     }
   *   })
   *
   */

  blueprints: {

    byId: {
      getPayload: function (reducerState, params) {
        var key = params.id;
        return reducerState[key];
      },

      callAction: function (action, params) {
        var id = params.id;
        var query = params.query;
        return action(id, query).payload;
      }
    }

  },

  // reducerActionMap: { ... }

};

```

The blueprints that exist by default are `find`, `byId`, and `singleton`. Using this property, you can override any of them by providing a key with a matching name, or you can extend the defaults with new blueprints.

### Motivation
The motivation for this PR came from a desire to modify the default `byId` behavior in order to pass query parameters to the `get` action, such as in this `connect` call:

```jsx
@lore.connect(function(getState, props){
  return {
    tweet: getState('tweet.byId', {
      id: 1,
      query: {
        _embed: 'user'
      }
    })
  }
})
```

Since that wasn't the current behavior (the map assumed the only parameter was the id), I wanted to modify the default blueprint. But that wasn't possible. Now it is : )