### PR TITLE
[circle-ci] update config for 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.11.1
+    steps:
+      - checkout
+      - run:
+          name: install-packages
+          command: npm install
+      - run:
+          name: lint
+          command: npm run lint
+      - run:
+          name: test
+          command: npm run test

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  node:
-    version: 6.11.1
-
-dependencies:
-  pre:
-    - npm install -g npm


### PR DESCRIPTION
This PR updates the Circle CI config to use their 2.0 platform. Build times appear to be cut in half, and the config is more flexible.

The documentation for Circle CI 2.0 is located [here](https://circleci.com/docs/2.0/).